### PR TITLE
Coin control: Selection based tx fix

### DIFF
--- a/src/screens/Send/UTXOSelection.tsx
+++ b/src/screens/Send/UTXOSelection.tsx
@@ -46,7 +46,7 @@ function UTXOSelection({ route }: any) {
     }
     recipients.push({
       address,
-      amount,
+      amount: BtcToSats(amount),
     });
     dispatch(
       sendPhaseOne({


### PR DESCRIPTION
Issue source: BTC value was being passed as the amount for recipient's output utxo on the UTXO selection screen
Fix: Passed in the amount in Sats

Addresses #3336 