### PR TITLE
PSBT::addInput - use cached mfp

### DIFF
--- a/src/core/wallets/operations/index.ts
+++ b/src/core/wallets/operations/index.ts
@@ -674,9 +674,7 @@ export default class WalletOperations {
         masterFingerprint = mfp;
       } else {
         path = `${(wallet as Wallet).derivationDetails.xDerivationPath}/${subPath.join('/')}`;
-        masterFingerprint = WalletUtilities.getFingerprintFromMnemonic(
-          (wallet as Wallet).derivationDetails.mnemonic
-        );
+        masterFingerprint = WalletUtilities.getFingerprintForWallet(wallet as Wallet);
       }
 
       const bip32Derivation = [

--- a/src/core/wallets/operations/utils.ts
+++ b/src/core/wallets/operations/utils.ts
@@ -74,6 +74,10 @@ export default class WalletUtilities {
     return WalletUtilities.getFingerprintFromSeed(seed);
   }
 
+  static getFingerprintForWallet(wallet: Wallet) {
+    return whirlPoolWalletTypes.includes(wallet.type) ? wallet.depositWalletId : wallet.id;
+  }
+
   static getFingerprintFromExtendedKey = (
     extendedKey: string,
     network: bitcoinJS.networks.Network


### PR DESCRIPTION
Issue: fingerprint generation via mnemonic leads to significant delay while adding inputs
Fix: use the cached fingerprint while adding inputs to PSBT

Partially addresses #3330 