### PR TITLE
Buy with ramp for UK #3940

### DIFF
--- a/src/screens/WalletDetails/components/RampModal.tsx
+++ b/src/screens/WalletDetails/components/RampModal.tsx
@@ -8,13 +8,21 @@ import { fetchRampReservation } from 'src/services/ramp';
 import { wp } from 'src/constants/responsive';
 import Text from 'src/components/KeeperText';
 import GradientIcon from './GradientIcon';
+import { useAppSelector } from 'src/store/hooks';
+import { getCountry } from 'react-native-localize';
 
 function RampBuyContent({ balance, setShowBuyRampModal, receivingAddress, name }) {
   const { colorMode } = useColorMode();
+  const { currencyCode } = useAppSelector((state) => state.settings);
+
   const buyWithRamp = (address: string) => {
     try {
       setShowBuyRampModal(false);
-      Linking.openURL(fetchRampReservation({ receiveAddress: address }));
+      if (currencyCode === 'GBP' || getCountry() === 'UK') {
+        Linking.openURL('https://ramp.network/buy#');
+      } else {
+        Linking.openURL(fetchRampReservation({ receiveAddress: address }));
+      }
     } catch (error) {
       console.log(error);
     }


### PR DESCRIPTION
Buy with Ramp isn't working in UK due to some policy changes. So we're processing buy requests with a [vanila link](https://ramp.network/buy#). This is a temporary fix, we may remove it in the future once it starts working again. 