### PR TITLE
Multiple ecc init

### DIFF
--- a/src/core/wallets/operations/utils.ts
+++ b/src/core/wallets/operations/utils.ts
@@ -731,36 +731,6 @@ export default class WalletUtilities {
     } else return { outputs, changeAddress };
   };
 
-  // test-wallet specific utilities
-  static getTestcoins = async (
-    recipientAddress: string,
-    network: bitcoinJS.networks.Network
-  ): Promise<{
-    txid: any;
-    funded: any;
-  }> => {
-    if (network === bitcoinJS.networks.bitcoin) {
-      throw new Error('Invalid network: failed to fund via testnet');
-    }
-
-    const SATOSHIS_IN_BTC = 1e8;
-    const amount = 10000 / SATOSHIS_IN_BTC;
-    try {
-      const res = await RestClient.post(`${config.RELAY}/testnetFaucet`, {
-        recipientAddress,
-        amount,
-      });
-      const { txid, funded } = res.data || res.json;
-      return {
-        txid,
-        funded,
-      };
-    } catch (err) {
-      if (err.response) throw new Error(err.response.data.err);
-      if (err.code) throw new Error(err.code);
-    }
-  };
-
   static generateXpubFromMetaData = (cryptoAccount: CryptoAccount) => {
     const version = Buffer.from('02aa7ed3', 'hex');
     const hdKey = cryptoAccount.getOutputDescriptors()[0].getCryptoKey() as CryptoHDKey;

--- a/src/services/electrum/client.ts
+++ b/src/services/electrum/client.ts
@@ -8,6 +8,8 @@ import { ElectrumTransaction, ElectrumUTXO } from './interface';
 import torrific from './torrific';
 import RestClient, { TorStatus } from '../rest/RestClient';
 import { cryptoRandom } from '../operations/encryption';
+import ecc from '../../core/wallets/operations/taproot-utils/noble_ecc';
+bitcoinJS.initEccLib(ecc);
 
 function shufflePeers(peers) {
   for (let i = peers.length - 1; i > 0; i--) {

--- a/src/services/whirlpool/client.ts
+++ b/src/services/whirlpool/client.ts
@@ -16,6 +16,8 @@ import {
   WhirlpoolInput,
 } from 'src/nativemodules/interface';
 import { hash256 } from 'src/services/operations/encryption';
+import ecc from '../../core/wallets/operations/taproot-utils/noble_ecc';
+bitcoinJS.initEccLib(ecc);
 
 const LOCALHOST = '127.0.0.1';
 export const TOR_CONFIG: TorConfig = {


### PR DESCRIPTION
Initializing bitcoinJS with ecc in one file should be sufficient as long as the initialization happens before any other code uses it, as the modules are cached after the first time they are loaded. So if we initialize bitcoinJS in one module, and then require or import it in another module, it will already be initialized.

However, we need to ensure that the file where we initialize bitcoinJS is run before any other file that uses bitcoinJS. This can be tricky to manage, especially in larger codebases, so we prefer to initialize such libraries in every file where they're used, just to be sure.