### PR TITLE
Create New wallet without the 'Auto Transfer' value

### DIFF
--- a/src/screens/EnterWalletDetailScreen/EnterWalletDetailScreen.tsx
+++ b/src/screens/EnterWalletDetailScreen/EnterWalletDetailScreen.tsx
@@ -88,7 +88,7 @@ function EnterWalletDetailScreen({ route }) {
         },
         transferPolicy: {
           id: uuidv4(),
-          threshold: parseInt(transferPolicy),
+          threshold: transferPolicy ? parseInt(transferPolicy) : 0,
         },
       },
     };


### PR DESCRIPTION
Fix for new wallet creation without 'Auto Transfer' value.  If the transfer policy is empty it results in parseInt failing with 'NaN'. Added a check for the same.