### PR TITLE
Remove NFC device requirement from Info.plist

### DIFF
--- a/ios/hexa_keeper/Info.plist
+++ b/ios/hexa_keeper/Info.plist
@@ -81,7 +81,6 @@
 	<key>UIRequiredDeviceCapabilities</key>
 	<array>
 		<string>armv7</string>
-		<string>nfc</string>
 	</array>
 	<key>UISupportedInterfaceOrientations</key>
 	<array>

--- a/ios/hexa_keeper_dev-Info.plist
+++ b/ios/hexa_keeper_dev-Info.plist
@@ -81,7 +81,6 @@
 	<key>UIRequiredDeviceCapabilities</key>
 	<array>
 		<string>armv7</string>
-		<string>nfc</string>
 	</array>
 	<key>UISupportedInterfaceOrientations</key>
 	<array>


### PR DESCRIPTION
* iOS doesn't let you install the app if UIRequiredDeviceCapabilities has NFC.
* Removed the required compatibility check