### PR TITLE
Fix PSBT signature addition in WalletOperations

### DIFF
--- a/src/services/wallets/operations/index.ts
+++ b/src/services/wallets/operations/index.ts
@@ -1278,12 +1278,14 @@ export default class WalletOperations {
         if (signerType === SignerType.TAPSIGNER && config.NETWORK_TYPE === NetworkType.MAINNET) {
           for (const { inputsToSign } of signingPayload) {
             for (const { inputIndex, publicKey, signature, sighashType } of inputsToSign) {
-              PSBT.addSignedDigest(
-                inputIndex,
-                Buffer.from(publicKey, 'hex'),
-                Buffer.from(signature, 'hex'),
-                sighashType
-              );
+              if (signature) {
+                PSBT.addSignedDigest(
+                  inputIndex,
+                  Buffer.from(publicKey, 'hex'),
+                  Buffer.from(signature, 'hex'),
+                  sighashType
+                );
+              }
             }
           }
         }


### PR DESCRIPTION
acknowledges: https://github.com/bithyve/bitcoin-keeper/issues/4354

* Checks and updates PSBT for tapsigner only if signatures are available