### PR TITLE
Testnet sats: moved to backend(amt)

### DIFF
--- a/src/hooks/useTestSats.tsx
+++ b/src/hooks/useTestSats.tsx
@@ -24,7 +24,7 @@ const useTestSats = ({ wallet }) => {
   useEffect(() => {
     setAppLoading(false);
     if (testCoinsReceived) {
-      showToast('Test Sats Received', <TickIcon />);
+      showToast('Testnet Sats Received', <TickIcon />);
       setTimeout(() => {
         dispatch(setTestCoinsReceived(false));
         navigation.goBack();

--- a/src/hooks/useTestSats.tsx
+++ b/src/hooks/useTestSats.tsx
@@ -24,7 +24,7 @@ const useTestSats = ({ wallet }) => {
   useEffect(() => {
     setAppLoading(false);
     if (testCoinsReceived) {
-      showToast('50000 Sats Received', <TickIcon />);
+      showToast('Test Sats Received', <TickIcon />);
       setTimeout(() => {
         dispatch(setTestCoinsReceived(false));
         navigation.goBack();

--- a/src/services/backend/Relay.ts
+++ b/src/services/backend/Relay.ts
@@ -452,14 +452,12 @@ export default class Relay {
     txid: any;
     funded: any;
   }> => {
-    if (network === NetworkType.MAINNET) {
+    if (network === NetworkType.MAINNET)
       throw new Error('Invalid network: failed to fund via testnet');
-    }
-    const amount = 50000 / SATOSHIS_IN_BTC;
+
     try {
       const res = await RestClient.post(`${config.RELAY}testnetFaucet`, {
         recipientAddress,
-        amount,
       });
       const { txid, funded } = res.data;
       return {


### PR DESCRIPTION
Hands over the quantity decision to backend. Simplifies funding changes based on fee variation on testnet.

Partly addresses #4392 and improves upon #4396