### PR TITLE
fixes pending icon showing on cached transactions

### DIFF
--- a/src/components/TransactionElement.tsx
+++ b/src/components/TransactionElement.tsx
@@ -46,7 +46,7 @@ function TransactionElement({
             backgroundColor={!isCached ? `${colorMode}.TransactionIconBackColor` : null}
             style={styles.circle}
           >
-            {transaction.confirmations === 0 && (
+            {transaction.confirmations === 0 && !isCached && (
               <Box style={styles.transaction}>
                 <TransactionPendingIcon />
               </Box>


### PR DESCRIPTION
Addresses: 
#4662

fixes pending icon showing on cached transactions

![simulator_screenshot_AF120B22-666E-4EE0-8C32-EE31F1EDA65E](https://github.com/bithyve/bitcoin-keeper/assets/28229449/9da4295a-38d2-418c-bfe9-06361a1875f4)
