### PR TITLE
Show tx note (if exists) instead of tx ID in the transaction element

### DIFF
--- a/src/components/TransactionElement.tsx
+++ b/src/components/TransactionElement.tsx
@@ -15,18 +15,24 @@ import IconArrow from 'src/assets/images/icon_arrow_grey.svg';
 import Text from 'src/components/KeeperText';
 import CurrencyInfo from 'src/screens/Home/components/CurrencyInfo';
 import Colors from 'src/theme/Colors';
+import useLabelsNew from 'src/hooks/useLabelsNew';
+import { Wallet } from 'src/services/wallets/interfaces/wallet';
+import { Vault } from 'src/services/wallets/interfaces/vault';
 
 function TransactionElement({
   transaction,
+  wallet,
   onPress = () => {},
   index,
   isCached,
 }: {
   transaction: Transaction;
+  wallet: Wallet | Vault;
   onPress?: () => void;
   index?: number;
   isCached: boolean;
 }) {
+  const { labels } = useLabelsNew({ txid: transaction.txid, wallet });
   const { colorMode } = useColorMode();
   const date = moment(transaction?.date)?.format('DD MMM YY  •  HH:mm A');
 
@@ -68,7 +74,7 @@ function TransactionElement({
               numberOfLines={1}
               style={styles.transactionDate}
             >
-              {transaction?.txid}
+              {labels[transaction.txid]?.[0]?.name || transaction?.txid}
             </Text>
           </Box>
         </Box>

--- a/src/screens/Vault/AllTransactions.tsx
+++ b/src/screens/Vault/AllTransactions.tsx
@@ -29,7 +29,9 @@ function AllTransactions({ route }) {
 
   const vaultTrans: Transaction[] = vault?.specs?.transactions || [];
   const walletTrans: Transaction[] = wallet?.specs.transactions || [];
-  const renderTransactionElement = ({ item }) => <TransactionElement transaction={item} />;
+  const renderTransactionElement = ({ item }) => (
+    <TransactionElement transaction={item} wallet={wallet} />
+  );
 
   const pullDownRefresh = () => {
     setPullRefresh(true);

--- a/src/screens/Vault/VaultDetails.tsx
+++ b/src/screens/Vault/VaultDetails.tsx
@@ -165,6 +165,7 @@ function TransactionList({
   const renderTransactionElement = ({ item }) => (
     <TransactionElement
       transaction={item}
+      wallet={vault}
       isCached={item?.isCached}
       onPress={() => {
         if (item?.isCached) {

--- a/src/screens/Vault/components/TransactionsAndUTXOs.tsx
+++ b/src/screens/Vault/components/TransactionsAndUTXOs.tsx
@@ -39,6 +39,7 @@ function TransactionsAndUTXOs({
   const renderTransactionElement = ({ item }) => (
     <TransactionElement
       transaction={item}
+      wallet={vault}
       onPress={() => {
         navigation.dispatch(
           CommonActions.navigate('TransactionDetails', {
@@ -53,7 +54,12 @@ function TransactionsAndUTXOs({
     <>
       <VStack>
         <HStack justifyContent="space-between">
-          <Text color={`${colorMode}.textBlack`} marginLeft={wp(3)} fontSize={16} letterSpacing={1.28}>
+          <Text
+            color={`${colorMode}.textBlack`}
+            marginLeft={wp(3)}
+            fontSize={16}
+            letterSpacing={1.28}
+          >
             Transactions
           </Text>
           {transactions.length ? (

--- a/src/screens/ViewTransactions/TransactionDetails.tsx
+++ b/src/screens/ViewTransactions/TransactionDetails.tsx
@@ -133,7 +133,8 @@ function TransactionDetails({ route }) {
   }
   const redirectToBlockExplorer = () => {
     openLink(
-      `https://mempool.space${config.NETWORK_TYPE === NetworkType.TESTNET ? '/testnet' : ''}/tx/${transaction.txid
+      `https://mempool.space${config.NETWORK_TYPE === NetworkType.TESTNET ? '/testnet' : ''}/tx/${
+        transaction.txid
       }`
     );
   };
@@ -210,7 +211,10 @@ function TransactionDetails({ route }) {
           <TouchableOpacity testID="btn_transactionNote" onPress={() => setVisible(true)}>
             <InfoCard
               title={common.note}
-              describtion={labels[transaction.txid][0]?.name || 'Add a note'}
+              describtion={
+                labels[transaction.txid][0]?.name ||
+                common.addNote.charAt(0) + common.addNote.slice(1).toLowerCase()
+              }
               showIcon
               letterSpacing={2.4}
               Icon={updatingLabel ? <ActivityIndicator /> : <Edit />}

--- a/src/screens/WalletDetails/components/Transactions.tsx
+++ b/src/screens/WalletDetails/components/Transactions.tsx
@@ -14,6 +14,7 @@ function TransactionItem({ item, wallet, navigation, index }) {
   return (
     <TransactionElement
       transaction={item}
+      wallet={wallet}
       index={index}
       isCached={item?.isCached}
       onPress={


### PR DESCRIPTION
In the tx list item, if a tx note exists, show it instead of the tx ID, otherwise show the tx ID like before.