### PR TITLE
Disallow going back to edit after TX is created and cached

### DIFF
--- a/src/screens/Send/SendConfirmation.tsx
+++ b/src/screens/Send/SendConfirmation.tsx
@@ -1177,6 +1177,21 @@ function SendConfirmation({ route }) {
         title="Send Confirmation"
         subtitle={subTitle}
         rightComponent={<CurrencyTypeSwitch />}
+        onPressHandler={() => {
+          if (navigation.getState().index > 2 && isCachedTransaction) {
+            navigation.dispatch(
+              CommonActions.reset({
+                index: 1,
+                routes: [
+                  { name: 'Home' },
+                  { name: 'VaultDetails', params: { vaultId: sender?.id } },
+                ],
+              })
+            );
+          } else {
+            navigation.goBack();
+          }
+        }}
       />
       <ScrollView
         style={styles.container}


### PR DESCRIPTION
For vaults, if the transaction if already created and cached, the navigation back button will go back to the VaultDetails screen instead of showing the edit option for the already cached transaction.

Addresses #5241