### PR TITLE
Show address when verifying using desktop app

### DIFF
--- a/src/components/KeeperHeader.tsx
+++ b/src/components/KeeperHeader.tsx
@@ -122,6 +122,7 @@ const getStyles = (marginLeft: boolean) =>
       fontSize: 18,
     },
     addWalletDescription: {
+      marginTop: 10,
       fontSize: 14,
       lineHeight: 18,
       width: windowWidth * 0.8,

--- a/src/screens/Recieve/ReceiveAddress.tsx
+++ b/src/screens/Recieve/ReceiveAddress.tsx
@@ -37,13 +37,14 @@ function ReceiveAddress({ address }: Props) {
       }}
       backgroundColor={`${colorMode}.seashellWhite`}
       style={styles.container}
+      borderColor={`${colorMode}.greyBorder`}
     >
       <Box style={styles.textContainer}>
         <Text
           color={`${colorMode}.secondaryText`}
           ellipsizeMode="middle"
-          numberOfLines={1}
-          fontSize={13}
+          numberOfLines={2}
+          style={styles.value}
         >
           {address}
         </Text>
@@ -67,11 +68,15 @@ const styles = StyleSheet.create({
     alignItems: 'center',
     width: '100%',
     borderRadius: 10,
-    height: hp(60),
+    borderWidth: 1,
+    height: hp(63),
     marginVertical: hp(20),
+    paddingVertical: hp(11),
+    paddingHorizontal: wp(8),
   },
   value: {
     fontSize: 13,
+    lineHeight: 20,
     letterSpacing: 0.39,
   },
   iconContainer: {
@@ -79,8 +84,8 @@ const styles = StyleSheet.create({
     margin: 2,
     alignItems: 'center',
     justifyContent: 'center',
-    width: wp(56),
-    height: '95%',
+    width: wp(42),
+    height: hp(42),
   },
   textContainer: {
     width: '80%',

--- a/src/screens/Recieve/ReceiveAddress.tsx
+++ b/src/screens/Recieve/ReceiveAddress.tsx
@@ -40,12 +40,7 @@ function ReceiveAddress({ address }: Props) {
       borderColor={`${colorMode}.greyBorder`}
     >
       <Box style={styles.textContainer}>
-        <Text
-          color={`${colorMode}.secondaryText`}
-          ellipsizeMode="middle"
-          numberOfLines={2}
-          style={styles.value}
-        >
+        <Text color={`${colorMode}.secondaryText`} style={styles.value}>
           {address}
         </Text>
       </Box>
@@ -69,7 +64,6 @@ const styles = StyleSheet.create({
     width: '100%',
     borderRadius: 10,
     borderWidth: 1,
-    height: hp(63),
     marginVertical: hp(20),
     paddingVertical: hp(11),
     paddingHorizontal: wp(8),

--- a/src/screens/Recieve/ReceiveQR.tsx
+++ b/src/screens/Recieve/ReceiveQR.tsx
@@ -1,0 +1,63 @@
+import React, { useContext } from 'react';
+import { Box, useColorMode } from 'native-base';
+import { StyleSheet } from 'react-native';
+import { LocalizationContext } from 'src/context/Localization/LocContext';
+import { hp, wp } from 'src/constants/responsive';
+import Text from 'src/components/KeeperText';
+import QRCode from 'react-native-qrcode-svg';
+
+type Props = {
+  qrValue: string;
+};
+
+function ReceiveQR({ qrValue }: Props) {
+  const { colorMode } = useColorMode();
+
+  const { translations } = useContext(LocalizationContext);
+  const { wallet: walletTranslation } = translations;
+
+  return (
+    <Box
+      testID="view_recieveAddressQR"
+      style={styles.qrWrapper}
+      borderColor={`${colorMode}.qrBorderColor`}
+    >
+      {/* Passing 'address' is needed since passing empty string will throw error in QRCode component */}
+      <QRCode value={qrValue || 'address'} logoBackgroundColor="transparent" size={hp(175)} />
+      <Box background={`${colorMode}.QrCode`} style={styles.receiveAddressWrapper}>
+        <Text
+          bold
+          style={styles.receiveAddressText}
+          color={`${colorMode}.recieverAddress`}
+          numberOfLines={1}
+        >
+          {walletTranslation.receiveAddress}
+        </Text>
+      </Box>
+    </Box>
+  );
+}
+
+const styles = StyleSheet.create({
+  qrWrapper: {
+    marginTop: 0,
+    alignItems: 'center',
+    alignSelf: 'center',
+    width: wp(225),
+    borderWidth: 30,
+    borderBottomWidth: 15,
+  },
+  receiveAddressWrapper: {
+    height: hp(28),
+    width: '100%',
+    justifyContent: 'center',
+  },
+  receiveAddressText: {
+    textAlign: 'center',
+    fontSize: 12,
+    letterSpacing: 1.08,
+    width: '100%',
+  },
+});
+
+export default ReceiveQR;

--- a/src/screens/Recieve/ReceiveScreen.tsx
+++ b/src/screens/Recieve/ReceiveScreen.tsx
@@ -6,14 +6,13 @@ import { Keyboard, ScrollView, StyleSheet, View } from 'react-native';
 import React, { useContext, useEffect, useState } from 'react';
 import AppNumPad from 'src/components/AppNumPad';
 import Buttons from 'src/components/Buttons';
-import QRCode from 'react-native-qrcode-svg';
 
 import BtcGreen from 'src/assets/images/btc_round_green.svg';
 import KeeperHeader from 'src/components/KeeperHeader';
 import ScreenWrapper from 'src/components/ScreenWrapper';
 import { Wallet } from 'src/services/wallets/interfaces/wallet';
 import WalletUtilities from 'src/services/wallets/operations/utils';
-import { hp, windowHeight, wp } from 'src/constants/responsive';
+import { hp, wp } from 'src/constants/responsive';
 import Note from 'src/components/Note/Note';
 import KeeperModal from 'src/components/KeeperModal';
 import WalletOperations from 'src/services/wallets/operations';
@@ -26,7 +25,7 @@ import ReceiveAddress from './ReceiveAddress';
 import useSigners from 'src/hooks/useSigners';
 import { SignerType } from 'src/services/wallets/enums';
 import { CommonActions, useNavigation } from '@react-navigation/native';
-import ReceiveGreen from 'src/assets/images/receive-green.svg';
+import ReceiveQR from './ReceiveQR';
 const AddressVerifiableSigners = [SignerType.BITBOX02, SignerType.LEDGER, SignerType.TREZOR];
 
 function ReceiveScreen({ route }: { route }) {
@@ -43,7 +42,6 @@ function ReceiveScreen({ route }: { route }) {
   const { translations } = useContext(LocalizationContext);
   const { common, home, wallet: walletTranslation } = translations;
 
-  const [btmCtrHeight, setBtmCtrHeight] = useState(0);
   const navigation = useNavigation();
   const { vaultSigners } = useSigners(wallet.id);
   const [addVerifiableSigners, setAddVerifiableSigners] = useState([]);
@@ -154,27 +152,7 @@ function ReceiveScreen({ route }: { route }) {
       <KeeperHeader title={common.receive} subtitle={walletTranslation.receiveSubTitle} />
       <Box height={hp(10)} />
       <ScrollView style={{ flex: 1 }} showsVerticalScrollIndicator={false}>
-        <Box
-          testID="view_recieveAddressQR"
-          style={styles.qrWrapper}
-          borderColor={`${colorMode}.qrBorderColor`}
-        >
-          <QRCode
-            value={paymentURI || receivingAddress || 'address'}
-            logoBackgroundColor="transparent"
-            size={hp(175)}
-          />
-          <Box background={`${colorMode}.QrCode`} style={styles.receiveAddressWrapper}>
-            <Text
-              bold
-              style={styles.receiveAddressText}
-              color={`${colorMode}.recieverAddress`}
-              numberOfLines={1}
-            >
-              {walletTranslation.receiveAddress}
-            </Text>
-          </Box>
-        </Box>
+        <ReceiveQR qrValue={paymentURI || receivingAddress} />
         <Box style={styles.addressContainer}>
           <ReceiveAddress address={paymentURI || receivingAddress} />
           <MenuItemButton
@@ -185,22 +163,9 @@ function ReceiveScreen({ route }: { route }) {
           />
         </Box>
       </ScrollView>
-      <Box
-        style={styles.BottomContainer}
-        backgroundColor={`${colorMode}.primaryBackground`}
-        onLayout={(event) => setBtmCtrHeight(event.nativeEvent.layout.height)}
-      >
+      <Box style={styles.BottomContainer} backgroundColor={`${colorMode}.primaryBackground`}>
         {
           <Box>
-            <Note
-              title={'Note'}
-              subtitle={
-                wallet.entityKind === 'VAULT'
-                  ? walletTranslation.addressReceiveDirectly
-                  : home.reflectSats
-              }
-              subtitleColor="GreyText"
-            />
             {wallet.entityKind === 'VAULT' && addVerifiableSigners?.length > 0 && (
               <VerifyAddressBtn />
             )}
@@ -227,25 +192,6 @@ const styles = StyleSheet.create({
     marginTop: hp(10),
     width: '95%',
     alignSelf: 'center',
-  },
-  qrWrapper: {
-    marginTop: 0,
-    alignItems: 'center',
-    alignSelf: 'center',
-    width: hp(225),
-    borderWidth: 30,
-    borderBottomWidth: 15,
-  },
-  receiveAddressWrapper: {
-    height: 28,
-    width: '100%',
-    justifyContent: 'center',
-  },
-  receiveAddressText: {
-    textAlign: 'center',
-    fontSize: 12,
-    letterSpacing: 1.08,
-    width: '100%',
   },
   Container: {
     padding: 10,
@@ -286,7 +232,7 @@ const styles = StyleSheet.create({
     borderRadius: 10,
     alignItems: 'center',
     marginTop: hp(15),
-    marginBottom: hp(5),
+    marginBottom: hp(20),
   },
   verifyAddressBtnText: {
     fontSize: 14,

--- a/src/screens/Recieve/ReceiveScreen.tsx
+++ b/src/screens/Recieve/ReceiveScreen.tsx
@@ -232,6 +232,7 @@ const styles = StyleSheet.create({
     alignSelf: 'center',
     width: hp(250),
     borderWidth: 30,
+    borderBottomWidth: 15,
   },
   receiveAddressWrapper: {
     height: 28,

--- a/src/screens/Recieve/ReceiveScreen.tsx
+++ b/src/screens/Recieve/ReceiveScreen.tsx
@@ -133,18 +133,18 @@ function ReceiveScreen({ route }: { route }) {
   const VerifyAddressBtn = () => {
     return (
       <Pressable
-        backgroundColor={`${colorMode}.seashellWhite`}
-        style={styles.verifyAddCtr}
-        mb={btmCtrHeight + hp(60)}
+        style={[styles.verifyAddressBtn]}
+        backgroundColor={`${colorMode}.greenButtonBackground`}
         onPress={onVerifyAddress}
       >
-        <ReceiveGreen />
-        <Box>
-          <Text fontSize={13}>Receive</Text>
-          <Text fontSize={12} color={`${colorMode}.GreyText`}>
-            {'Verify the address'}
-          </Text>
-        </Box>
+        <Text
+          numberOfLines={1}
+          style={styles.verifyAddressBtnText}
+          color={`${colorMode}.buttonText`}
+          bold
+        >
+          {'Verify Address on Device'}
+        </Text>
       </Pressable>
     );
   };
@@ -162,7 +162,7 @@ function ReceiveScreen({ route }: { route }) {
           <QRCode
             value={paymentURI || receivingAddress || 'address'}
             logoBackgroundColor="transparent"
-            size={hp(200)}
+            size={hp(175)}
           />
           <Box background={`${colorMode}.QrCode`} style={styles.receiveAddressWrapper}>
             <Text
@@ -183,25 +183,29 @@ function ReceiveScreen({ route }: { route }) {
             title={home.AddAmount}
             subTitle={walletTranslation.addSpecificInvoiceAmt}
           />
-          {wallet.entityKind === 'VAULT' && addVerifiableSigners?.length > 0 && (
-            <VerifyAddressBtn />
-          )}
         </Box>
       </ScrollView>
       <Box
-        style={styles.Note}
+        style={styles.BottomContainer}
         backgroundColor={`${colorMode}.primaryBackground`}
         onLayout={(event) => setBtmCtrHeight(event.nativeEvent.layout.height)}
       >
-        <Note
-          title={'Note'}
-          subtitle={
-            wallet.entityKind === 'VAULT'
-              ? walletTranslation.addressReceiveDirectly
-              : home.reflectSats
-          }
-          subtitleColor="GreyText"
-        />
+        {
+          <Box>
+            <Note
+              title={'Note'}
+              subtitle={
+                wallet.entityKind === 'VAULT'
+                  ? walletTranslation.addressReceiveDirectly
+                  : home.reflectSats
+              }
+              subtitleColor="GreyText"
+            />
+            {wallet.entityKind === 'VAULT' && addVerifiableSigners?.length > 0 && (
+              <VerifyAddressBtn />
+            )}
+          </Box>
+        }
       </Box>
       <KeeperModal
         visible={modalVisible}
@@ -219,18 +223,16 @@ function ReceiveScreen({ route }: { route }) {
 }
 
 const styles = StyleSheet.create({
-  Note: {
-    position: 'absolute',
-    bottom: hp(20),
-    width: '100%',
-    paddingHorizontal: 30,
-    zIndex: 1,
+  BottomContainer: {
+    marginTop: hp(10),
+    width: '95%',
+    alignSelf: 'center',
   },
   qrWrapper: {
     marginTop: 0,
     alignItems: 'center',
     alignSelf: 'center',
-    width: hp(250),
+    width: hp(225),
     borderWidth: 30,
     borderBottomWidth: 15,
   },
@@ -277,15 +279,18 @@ const styles = StyleSheet.create({
   addressContainer: {
     marginHorizontal: wp(20),
   },
-  verifyAddCtr: {
-    marginTop: hp(15),
+  verifyAddressBtn: {
     width: '100%',
-    paddingVertical: 16,
-    paddingHorizontal: 23,
-    gap: 11,
+    paddingHorizontal: wp(35),
+    paddingVertical: hp(15),
     borderRadius: 10,
-    flexDirection: 'row',
     alignItems: 'center',
+    marginTop: hp(15),
+    marginBottom: hp(5),
+  },
+  verifyAddressBtnText: {
+    fontSize: 14,
+    letterSpacing: 0.84,
   },
 });
 

--- a/src/screens/Recieve/VerifyAddressSelectionScreen.tsx
+++ b/src/screens/Recieve/VerifyAddressSelectionScreen.tsx
@@ -37,7 +37,7 @@ function VerifyAddressSelectionScreen() {
   return (
     <ScreenWrapper backgroundcolor={`${colorMode}.primaryBackground`}>
       <ActivityIndicatorView visible={false} showLoader />
-      <KeeperHeader title="Verify Address" subtitle={`Select a Signer`} />
+      <KeeperHeader title="Verify Address" subtitle={vaultText.SelectSigner} />
       <FlatList
         contentContainerStyle={{ paddingTop: '5%' }}
         data={availableSigners}
@@ -51,7 +51,7 @@ function VerifyAddressSelectionScreen() {
                   vaultId,
                   type: signer.type,
                   mode: InteracationMode.ADDRESS_VERIFICATION,
-                  title: `Setting up ${signerName}`,
+                  title: `Connecting to ${signerName}`,
                   subtitle: vaultText.verifyAddDesc,
                 })
               );


### PR DESCRIPTION
This PR updates the verify address using the desktop app screen, but also makes slight changes to the Receive screen.

Addresses #5132 

![Screenshot_20241003_160930](https://github.com/user-attachments/assets/124dfd21-ae33-4373-a361-b27bdf4f06af)

![Screenshot_20241003_161438](https://github.com/user-attachments/assets/fb1d1cfd-3cc7-4444-9875-bd10d8a1031a)

![Screenshot_20241003_160910](https://github.com/user-attachments/assets/50209678-98a7-46a4-9aae-90b352603b6e)

![Screenshot_20241003_161028](https://github.com/user-attachments/assets/91db33ee-82b3-4737-af69-a98c33145c4f)

![Screenshot_20241003_161406](https://github.com/user-attachments/assets/15bb5192-8e11-4cbb-9967-ec3a652b05b2)

![Screenshot_20241003_161045](https://github.com/user-attachments/assets/6521e190-fd87-48a9-9561-3846ec66c6aa)
