### PR TITLE
Replace term air-gapped with cold wallet

### DIFF
--- a/src/screens/AddWalletScreen/Wallets.tsx
+++ b/src/screens/AddWalletScreen/Wallets.tsx
@@ -8,8 +8,6 @@ import useWallets from 'src/hooks/useWallets';
 import { WalletType } from 'src/services/wallets/enums';
 import { CommonActions } from '@react-navigation/native';
 import { VaultScheme } from 'src/services/wallets/interfaces/vault';
-import usePlan from 'src/hooks/usePlan';
-import { SubscriptionTier } from 'src/models/enums/SubscriptionTier';
 import KeeperModal from 'src/components/KeeperModal';
 import SignerCard from '../AddSigner/SignerCard';
 import AirGappedIcon from 'src/assets/images/airgapped.svg';
@@ -21,8 +19,6 @@ enum SingleKeyOptions {
 }
 function Wallets({ navigation }) {
   const { wallets } = useWallets({ getAll: true });
-  const { plan } = usePlan();
-  const isDiamondHand = plan === SubscriptionTier.L3.toUpperCase();
 
   const [singleKeyOptions, setSingleKeyOptions] = useState(false);
   const [selectedSingleKeyOption, setselectedSingleKeyOption] = useState(
@@ -63,7 +59,7 @@ function Wallets({ navigation }) {
     },
     {
       name: SingleKeyOptions.AIR_GAPPED,
-      title: 'Air Gapped',
+      title: 'Cold wallet',
       icon: <AirGappedIcon />,
       subTitle: 'Choose a key',
     },
@@ -101,7 +97,7 @@ function Wallets({ navigation }) {
     <Box>
       <OptionCard
         title="Single-key wallet"
-        description="Create a Hot Wallet or an Air-gapped Wallet"
+        description="Create a wallet using a single key"
         LeftIcon={<WalletGreenIcon />}
         callback={() => setSingleKeyOptions(true)}
       />
@@ -128,7 +124,7 @@ function Wallets({ navigation }) {
         visible={singleKeyOptions}
         close={() => setSingleKeyOptions(false)}
         title={'Single-key wallet'}
-        subTitle={'Create a Hot Wallet or an Air-gapped Wallet'}
+        subTitle={'Create a wallet using a single key'}
         buttonText={'Proceed'}
         buttonCallback={handleSingleKey}
         Content={Content}


### PR DESCRIPTION
Use the term "cold wallet" instead of "air-gapped" for creating a new single sig wallet.