### PR TITLE
Remove currency switch from device details screen

### DIFF
--- a/src/screens/Vault/SigningDeviceDetails.tsx
+++ b/src/screens/Vault/SigningDeviceDetails.tsx
@@ -412,7 +412,6 @@ function SigningDeviceDetails({ route }) {
             icon={SDIcons(signer.type, true, 26, 26).Icon}
           />
         }
-        rightComponent={<CurrencyTypeSwitch />}
       />
       <Box>
         <Text style={styles.recentHistoryText}>Recent History</Text>


### PR DESCRIPTION
Remove currency switch from device details screen. There's no reason for it to be there.