### PR TITLE
Ask user to choose wallet details cold wallet

### DIFF
--- a/src/screens/AddWalletScreen/Wallets.tsx
+++ b/src/screens/AddWalletScreen/Wallets.tsx
@@ -27,11 +27,7 @@ function Wallets({ navigation }) {
 
   const handleSingleKey = () => {
     setSingleKeyOptions(false);
-    if (selectedSingleKeyOption === SingleKeyOptions.HOT_WALLET) {
-      navigateToWalletCreation();
-    } else {
-      navigation.navigate('AddSigningDevice', { scheme: { m: 1, n: 1 }, isSSAddition: true });
-    }
+    navigateToWalletCreation();
   };
 
   const navigateToVaultSetup = (scheme: VaultScheme) => {
@@ -39,14 +35,16 @@ function Wallets({ navigation }) {
   };
 
   const navigateToWalletCreation = () => {
+    const isHotWallet = selectedSingleKeyOption === SingleKeyOptions.HOT_WALLET;
     navigation.navigate('EnterWalletDetail', {
-      name: `Wallet ${wallets.length + 1}`,
+      name: isHotWallet ? `Wallet ${wallets.length + 1}` : '',
       description: '',
       type: WalletType.DEFAULT,
+      isHotWallet: isHotWallet,
     });
   };
 
-  const handleCollaaborativeWalletCreation = () => {
+  const handleCollaborativeWalletCreation = () => {
     navigation.navigate('SetupCollaborativeWallet');
   };
 
@@ -118,7 +116,7 @@ function Wallets({ navigation }) {
         title="Collaborative"
         description="With contacts/devices"
         LeftIcon={<CollaborativeIcon />}
-        callback={handleCollaaborativeWalletCreation}
+        callback={handleCollaborativeWalletCreation}
       />
       <KeeperModal
         visible={singleKeyOptions}

--- a/src/screens/EnterWalletDetailScreen/EnterWalletDetailScreen.tsx
+++ b/src/screens/EnterWalletDetailScreen/EnterWalletDetailScreen.tsx
@@ -55,6 +55,7 @@ function EnterWalletDetailScreen({ route }) {
   const { wallet, choosePlan, common, importWallet } = translations;
   const [walletType, setWalletType] = useState(route.params?.type);
   const [walletName, setWalletName] = useState(route.params?.name);
+  const [isHotWallet, setIsHotWallet] = useState(route.params?.isHotWallet || false);
   const [walletCreatedModal, setWalletCreatedModal] = useState(false);
   const [walletLoading, setWalletLoading] = useState(false);
   const [walletDescription, setWalletDescription] = useState(route.params?.description);
@@ -106,6 +107,20 @@ function EnterWalletDetailScreen({ route }) {
     }
     dispatch(addNewWallets([newWallet]));
   }, [walletName, walletDescription, path, purpose, transferPolicy]);
+
+  const continueSelectSigner = useCallback(() => {
+    navigation.dispatch(
+      CommonActions.navigate({
+        name: 'AddSigningDevice',
+        params: {
+          name: walletName,
+          description: walletDescription,
+          scheme: { m: 1, n: 1 },
+          isSSAddition: true,
+        },
+      })
+    );
+  }, [walletName, walletDescription]);
 
   useEffect(() => {
     if (relayWalletUpdate) {
@@ -215,15 +230,17 @@ function EnterWalletDetailScreen({ route }) {
         title={walletType === WalletType.DEFAULT ? `${wallet.AddNewWallet}` : 'Import'}
         subtitle={wallet.AddNewWalletDescription}
         rightComponent={
-          <Pressable
-            style={styles.advancedContainer}
-            onPress={() => setAdvancedSettingsVisible(true)}
-          >
-            <SettingsIcon />
-            <Text color={`${colorMode}.BrownNeedHelp`} bold fontSize={13}>
-              Advanced
-            </Text>
-          </Pressable>
+          isHotWallet && (
+            <Pressable
+              style={styles.advancedContainer}
+              onPress={() => setAdvancedSettingsVisible(true)}
+            >
+              <SettingsIcon />
+              <Text color={`${colorMode}.BrownNeedHelp`} bold fontSize={13}>
+                Advanced
+              </Text>
+            </Pressable>
+          )
         }
         // To-Do-Learn-More
       />
@@ -234,7 +251,7 @@ function EnterWalletDetailScreen({ route }) {
               placeholder={wallet.WalletNamePlaceHolder}
               value={walletName}
               onChangeText={(value) => {
-                if (route.params?.name === walletName) {
+                if (route.params?.name && route.params?.name === walletName) {
                   setWalletName('');
                   return;
                 }
@@ -267,7 +284,7 @@ function EnterWalletDetailScreen({ route }) {
           <Breadcrumbs totalScreens={walletType === WalletType.DEFAULT ? 3 : 4} currentScreen={2} />
           <Buttons
             primaryText={common.proceed}
-            primaryCallback={createNewWallet}
+            primaryCallback={isHotWallet ? createNewWallet : continueSelectSigner}
             primaryDisable={!walletName}
             primaryLoading={walletLoading || relayWalletUpdateLoading}
           />

--- a/src/screens/Vault/AddSigningDevice.tsx
+++ b/src/screens/Vault/AddSigningDevice.tsx
@@ -944,8 +944,8 @@ function AddSigningDevice() {
         vaultCreating={vaultCreating}
         vaultKeys={vaultKeys}
         scheme={scheme}
-        name={isSSAddition ? 'Air-gapped Wallet' : name}
-        description={isSSAddition ? 'External signing device' : description}
+        name={name}
+        description={description}
         vaultId={vaultId}
         setGeneratedVaultId={setGeneratedVaultId}
         vaultType={

--- a/src/screens/Vault/VaultMigrationController.tsx
+++ b/src/screens/Vault/VaultMigrationController.tsx
@@ -141,8 +141,7 @@ function VaultMigrationController({
       const generatedVaultId = generateVaultId(signers, scheme);
       const deletedVaultIds = archivedVaults.map((vault) => vault.id);
       if (allVaultIds.includes(generatedVaultId) && !deletedVaultIds.includes(generatedVaultId)) {
-        Alert.alert('Vault with this configuration already exists');
-        navigation.goBack();
+        Alert.alert('Vault with this configuration already exists.');
       } else {
         setGeneratedVaultId(generatedVaultId);
         dispatch(addNewVault({ newVaultInfo: vaultInfo }));


### PR DESCRIPTION
When choosing cold wallet option for creating a single sig wallet, the user will now be prompted with the same Add New Wallet screen that shows up for creating a hot wallet (without the adnaced option which isn't relevant here). The default name is now empty for this so the user will need to choose a name, description is optional.

Addresses #5290 

![Screenshot_20241009_143803](https://github.com/user-attachments/assets/38b5cc8f-c16b-49c6-b108-5b0c54546a8b)
