### PR TITLE
Remove default nodes

### DIFF
--- a/src/context/Localization/language/en.json
+++ b/src/context/Localization/language/en.json
@@ -128,7 +128,12 @@
     "for": "For",
     "goToBackup": "Go to Backup",
     "Receipt": "Receipt",
-    "Later": "Later"
+    "Later": "Later",
+    "noElectrumServerTitle": "No Electrum Server Connected",
+    "noElectrumServerText": "You are not connected to any Electrum Server. Fetching your balances, receiving incoming transactions, and sending new transactions may not work. You can select a server to use in the Node Settings.",
+    "electrumServerConnectionFailedTitle": "Server Connection Failed",
+    "electrumServerConnectionFailedText": "Failed to connect to Electrum server. Fetching your balances, receiving incoming transactions, and sending new transactions may not work. Check your network connection and try again.",
+    "serverSettings": "Server Settings"
   },
   "noInternet": {
     "no": "No Internet",
@@ -810,7 +815,7 @@
     "SecurityAndLogin": "App Access",
     "SecurityAndLoginSubtitle": "Security, passcode and biometrics",
     "AppLevelSettings": "App-level settings",
-    "nodeSettingUsedSoFar": "Node settings used so far",
+    "manageElectrumServersSubtitle": "Manage your saved Electrum servers",
     "connectToMyNode": "Connect to my node",
     "connectToMyNodeSubtitle": "Disable to use Keeper's node",
     "nodesUsedPreviously": "Nodes connected previously",

--- a/src/context/Localization/language/es.json
+++ b/src/context/Localization/language/es.json
@@ -128,7 +128,12 @@
     "for": "For",
     "goToBackup": "Go to Backup",
     "Receipt": "Receipt",
-    "Later": "Later"
+    "Later": "Later",
+    "noElectrumServerTitle": "No Electrum Server Connected",
+    "noElectrumServerText": "You are not connected to any Electrum Server. Fetching your balances, receiving incoming transactions, and sending new transactions may not work. You can select a server to use in the Node Settings.",
+    "electrumServerConnectionFailedTitle": "Server Connection Failed",
+    "electrumServerConnectionFailedText": "Failed to connect to Electrum server. Fetching your balances, receiving incoming transactions, and sending new transactions may not work. Check your network connection and try again.",
+    "serverSettings": "Server Settings"
   },
   "noInternet": {
     "no": "No Internet",
@@ -808,7 +813,7 @@
     "SecurityAndLogin": "App Access",
     "SecurityAndLoginSubtitle": "Security, passcode and biometrics",
     "AppLevelSettings": "App-level settings",
-    "nodeSettingUsedSoFar": "Node settings used so far",
+    "manageElectrumServersSubtitle": "Manage your saved Electrum servers",
     "connectToMyNode": "Connect to my node",
     "connectToMyNodeSubtitle": "Disable to use Keeper's node",
     "nodesUsedPreviously": "Nodes connected previously",

--- a/src/screens/AppSettings/Node/NodeSettings.tsx
+++ b/src/screens/AppSettings/Node/NodeSettings.tsx
@@ -140,22 +140,25 @@ function NodeSettings() {
   };
 
   const onDisconnectToNode = async (selectedNode: NodeDetail) => {
-    let nodes = [...nodeList];
-
-    setLoading(true);
-    const node = { ...selectedNode };
-    await Node.disconnect(node);
-    node.isConnected = false;
-    Node.update(node, { isConnected: node.isConnected });
-    showToast(`Disconnected from ${node.host}`, <ToastErrorIcon />);
-
-    nodes = nodes.map((item) => {
-      if (item.id === node.id) return { ...node };
-      return item;
-    });
-    setNodeList(nodes);
-    setCurrentlySelectedNodeItem(null);
-    setLoading(false);
+    try {
+      let nodes = [...nodeList];
+      setLoading(true);
+      const node = { ...selectedNode };
+      Node.disconnect(node);
+      node.isConnected = false;
+      Node.update(node, { isConnected: node.isConnected });
+      showToast(`Disconnected from ${node.host}`, <ToastErrorIcon />);
+      nodes = nodes.map((item) => {
+        if (item.id === node.id) return { ...node };
+        return item;
+      });
+      setNodeList(nodes);
+      setCurrentlySelectedNodeItem(null);
+      setLoading(false);
+    } catch (error) {
+      console.log('Error disconnecting electrum client', error);
+      showToast(`Failed to disconnect from Electrum server`, <ToastErrorIcon />);
+    }
   };
 
   const onSelectedNodeitem = (selectedItem: NodeDetail) => {
@@ -163,7 +166,10 @@ function NodeSettings() {
   };
   return (
     <ScreenWrapper backgroundcolor={`${colorMode}.primaryBackground`} barStyle="dark-content">
-      <KeeperHeader title={settings.nodeSettings} subtitle={settings.nodeSettingUsedSoFar} />
+      <KeeperHeader
+        title={settings.nodeSettings}
+        subtitle={settings.manageElectrumServersSubtitle}
+      />
       {nodeList.length > 0 && (
         <Box style={styles.nodesListWrapper}>
           <FlatList
@@ -196,9 +202,9 @@ function NodeSettings() {
                     <Box style={styles.nodeButtons} backgroundColor={`${colorMode}.seashellWhite`}>
                       <TouchableOpacity
                         testID="btn_disconnetNode"
-                        onPress={() => {
-                          if (!isConnected) onConnectToNode(item);
-                          else onDisconnectToNode(item);
+                        onPress={async () => {
+                          if (!isConnected) await onConnectToNode(item);
+                          else await onDisconnectToNode(item);
                         }}
                       >
                         <Box

--- a/src/screens/Home/components/ElectrumDisconnectModal.tsx
+++ b/src/screens/Home/components/ElectrumDisconnectModal.tsx
@@ -1,41 +1,43 @@
-import { StyleSheet } from 'react-native';
 import React, { useContext } from 'react';
 import KeeperModal from 'src/components/KeeperModal';
 import { LocalizationContext } from 'src/context/Localization/LocContext';
 import { Box, useColorMode } from 'native-base';
-import { hp, wp } from 'src/constants/responsive';
+import { wp } from 'src/constants/responsive';
 import DowngradeToPleb from 'src/assets/images/downgradetopleb.svg';
 import DowngradeToPlebDark from 'src/assets/images/downgradetoplebDark.svg';
-import Text from 'src/components/KeeperText';
+import ElectrumClient from 'src/services/electrum/client';
 
 function ElectrumErrorContent() {
   const { colorMode } = useColorMode();
-  const { translations } = useContext(LocalizationContext);
-  const { common } = translations;
+
   return (
-    <Box width={wp(320)}>
-      <Box margin={hp(5)}>
+    <Box width="100%" alignItems="center" justifyContent="center">
+      <Box marginRight={wp(30)}>
         {colorMode === 'light' ? <DowngradeToPleb /> : <DowngradeToPlebDark />}
-      </Box>
-      <Box>
-        <Text color={`${colorMode}.greenText`} style={styles.networkText}>
-          Please try again later
-        </Text>
       </Box>
     </Box>
   );
 }
 
-function ElectrumDisconnectModal({ electrumErrorVisible, setElectrumErrorVisible }) {
+function ElectrumDisconnectModal({ navigation, electrumErrorVisible, setElectrumErrorVisible }) {
   const { colorMode } = useColorMode();
   const { translations } = useContext(LocalizationContext);
   const { common } = translations;
+
   return (
     <KeeperModal
       visible={electrumErrorVisible}
       close={() => setElectrumErrorVisible(false)}
-      title={common.connectionError}
-      subTitle={common.electrumErrorSubTitle}
+      title={
+        !ElectrumClient.getActivePeer()
+          ? common.noElectrumServerTitle
+          : common.electrumServerConnectionFailedTitle
+      }
+      subTitle={
+        !ElectrumClient.getActivePeer()
+          ? common.noElectrumServerText
+          : common.electrumServerConnectionFailedText
+      }
       buttonText={common.continue}
       modalBackground={`${colorMode}.modalWhiteBackground`}
       subTitleColor={`${colorMode}.secondaryText`}
@@ -43,17 +45,14 @@ function ElectrumDisconnectModal({ electrumErrorVisible, setElectrumErrorVisible
       buttonTextColor={`${colorMode}.white`}
       DarkCloseIcon={colorMode === 'dark'}
       buttonCallback={() => setElectrumErrorVisible(false)}
+      secondaryButtonText={common.serverSettings}
+      secondaryCallback={() => {
+        setElectrumErrorVisible(false);
+        navigation.navigate('NodeSettings');
+      }}
       Content={ElectrumErrorContent}
     />
   );
 }
 
 export default ElectrumDisconnectModal;
-
-const styles = StyleSheet.create({
-  networkText: {
-    fontSize: 13,
-    padding: 1,
-    letterSpacing: 0.65,
-  },
-});

--- a/src/screens/Home/components/HomeModals.tsx
+++ b/src/screens/Home/components/HomeModals.tsx
@@ -6,6 +6,7 @@ export function HomeModals({ electrumErrorVisible, setElectrumErrorVisible, navi
     <>
       <DowngradeModal navigation={navigation} />
       <ElectrumDisconnectModal
+        navigation={navigation}
         electrumErrorVisible={electrumErrorVisible}
         setElectrumErrorVisible={setElectrumErrorVisible}
       />

--- a/src/services/electrum/node.tsx
+++ b/src/services/electrum/node.tsx
@@ -39,8 +39,7 @@ export default class Node {
   public static update(nodeDetail: NodeDetail, propsToUpdate: any) {
     if (!nodeDetail) return null;
 
-    const schema = nodeDetail.isDefault ? RealmSchema.DefaultNodeConnect : RealmSchema.NodeConnect;
-    dbManager.updateObjectById(schema, nodeDetail.id.toString(), {
+    dbManager.updateObjectById(RealmSchema.NodeConnect, nodeDetail.id.toString(), {
       ...propsToUpdate,
     });
   }
@@ -48,25 +47,25 @@ export default class Node {
   public static delete(nodeDetail: NodeDetail) {
     if (!nodeDetail) return null;
 
-    const schema = nodeDetail.isDefault ? RealmSchema.DefaultNodeConnect : RealmSchema.NodeConnect;
-    const status: boolean = dbManager.deleteObjectById(schema, nodeDetail.id.toString());
+    const status: boolean = dbManager.deleteObjectById(
+      RealmSchema.NodeConnect,
+      nodeDetail.id.toString()
+    );
     return status;
   }
 
   public static getAllNodes(): NodeDetail[] {
-    const defaultNodes: NodeDetail[] = dbManager.getCollection(RealmSchema.DefaultNodeConnect);
-    const personalNodes: NodeDetail[] = dbManager.getCollection(RealmSchema.NodeConnect);
-    return [...defaultNodes, ...personalNodes];
+    return dbManager.getCollection(RealmSchema.NodeConnect) as unknown as NodeDetail[];
   }
 
   public static async connectToSelectedNode(selectedNode: NodeDetail) {
-    // connects to the selected node(in case of failure, won't have default/private nodes as fallback)
-    ElectrumClient.setActivePeer([], [], selectedNode);
+    // connects to the selected node
+    ElectrumClient.setActivePeer([], selectedNode);
     const { connected, connectedTo, error } = await ElectrumClient.connect();
     return { connected, connectedTo, error };
   }
 
-  public static async disconnect(selectedNode: NodeDetail) {
+  public static disconnect(selectedNode: NodeDetail) {
     const activePeer = ElectrumClient.getActivePeer();
     if (selectedNode.host === activePeer?.host && selectedNode.port === activePeer?.port) {
       ElectrumClient.forceDisconnect();

--- a/src/services/electrum/predefinedNodes.ts
+++ b/src/services/electrum/predefinedNodes.ts
@@ -5,10 +5,9 @@ export const predefinedTestnetNodes: NodeDetail[] = [
     id: 333, // sequence 3-x-x; avoids collision w/ own node
     host: 'testnet.qtornado.com',
     port: '51002',
-    isConnected: false,
+    isConnected: true,
     useKeeperNode: false,
     useSSL: true,
-    isDefault: true,
   },
 ];
 
@@ -20,7 +19,6 @@ export const predefinedMainnetNodes: NodeDetail[] = [
     isConnected: false,
     useKeeperNode: false,
     useSSL: true,
-    isDefault: true,
   },
   {
     id: 445,
@@ -29,16 +27,14 @@ export const predefinedMainnetNodes: NodeDetail[] = [
     isConnected: false,
     useKeeperNode: false,
     useSSL: true,
-    isDefault: true,
   },
   {
     id: 446,
     host: 'ecdsa.net',
     port: '110',
-    isConnected: false,
+    isConnected: true,
     useKeeperNode: false,
     useSSL: true,
-    isDefault: true,
   },
   {
     id: 447,
@@ -47,6 +43,5 @@ export const predefinedMainnetNodes: NodeDetail[] = [
     isConnected: false,
     useKeeperNode: false,
     useSSL: true,
-    isDefault: true,
   },
 ];

--- a/src/services/wallets/interfaces/index.ts
+++ b/src/services/wallets/interfaces/index.ts
@@ -195,5 +195,4 @@ export interface NodeDetail {
   isConnected: boolean;
   useKeeperNode: boolean;
   useSSL: boolean;
-  isDefault?: boolean;
 }

--- a/src/storage/realm/enum.ts
+++ b/src/storage/realm/enum.ts
@@ -30,7 +30,6 @@ export enum RealmSchema {
   InheritancePolicy = 'InheritancePolicy',
   TriggerPolicy = 'TriggerPolicy',
   Backup = 'Backup',
-  DefaultNodeConnect = 'DefaultNodeConnect',
   NodeConnect = 'NodeConnect',
   UAI = 'UAI',
   UAIDetails = 'UAIDetails',

--- a/src/storage/realm/schema/index.ts
+++ b/src/storage/realm/schema/index.ts
@@ -39,7 +39,7 @@ import { CloudBackupHistorySchema } from './cloudBackupHistory';
 import { BackupHistorySchema } from './backupHistory';
 import { StoreSubscriptionSchema } from './subscription';
 import { BackupSchema } from './backup';
-import { NodeConnectSchema, DefaultNodeConnectSchema } from './nodeConnect';
+import { NodeConnectSchema } from './nodeConnect';
 
 export default [
   KeeperAppSchema,
@@ -77,7 +77,6 @@ export default [
   VaultSignerSchema,
   VersionHistorySchema,
   BackupHistorySchema,
-  DefaultNodeConnectSchema,
   NodeConnectSchema,
   WhirlpoolConfigSchema,
   WhirlpoolWalletDetailsSchema,

--- a/src/storage/realm/schema/nodeConnect.ts
+++ b/src/storage/realm/schema/nodeConnect.ts
@@ -11,20 +11,5 @@ export const NodeConnectSchema: ObjectSchema = {
     useKeeperNode: 'bool',
     isConnected: 'bool',
     useSSL: 'bool',
-    isDefault: 'bool?',
-  },
-};
-
-// hosts default nodes
-export const DefaultNodeConnectSchema: ObjectSchema = {
-  name: RealmSchema.DefaultNodeConnect,
-  properties: {
-    id: 'int',
-    host: 'string',
-    port: 'string',
-    useKeeperNode: 'bool',
-    isConnected: 'bool',
-    useSSL: 'bool',
-    isDefault: 'bool',
   },
 };

--- a/src/store/reducers/network.ts
+++ b/src/store/reducers/network.ts
@@ -5,12 +5,12 @@ import { HistoricalInisightData } from 'src/nativemodules/interface';
 const initialState: {
   exchangeRates: ExchangeRates;
   averageTxFees: AverageTxFeesByNetwork;
-  defaultNodesSaved: Boolean;
+  initialNodesSaved: Boolean;
   oneDayInsight: HistoricalInisightData[];
 } = {
   exchangeRates: null,
   averageTxFees: null,
-  defaultNodesSaved: false,
+  initialNodesSaved: false,
   oneDayInsight: [],
 };
 
@@ -26,8 +26,8 @@ const networkSlice = createSlice({
       state.averageTxFees = action.payload;
     },
 
-    setDefaultNodesSaved: (state, action: PayloadAction<Boolean>) => {
-      state.defaultNodesSaved = action.payload;
+    setInitialNodesSaved: (state, action: PayloadAction<Boolean>) => {
+      state.initialNodesSaved = action.payload;
     },
     setOneDayInsight: (state, action: PayloadAction<HistoricalInisightData[]>) => {
       state.oneDayInsight = action.payload;
@@ -35,7 +35,7 @@ const networkSlice = createSlice({
   },
 });
 
-export const { setExchangeRates, setAverageTxFee, setDefaultNodesSaved, setOneDayInsight } =
+export const { setExchangeRates, setAverageTxFee, setInitialNodesSaved, setOneDayInsight } =
   networkSlice.actions;
 
 export default networkSlice.reducer;

--- a/src/store/sagas/login.ts
+++ b/src/store/sagas/login.ts
@@ -14,7 +14,7 @@ import { getReleaseTopic } from 'src/utils/releaseTopic';
 import messaging from '@react-native-firebase/messaging';
 import Relay from 'src/services/backend/Relay';
 import semver from 'semver';
-import { UAI, uaiType } from 'src/models/interfaces/Uai';
+import { uaiType } from 'src/models/interfaces/Uai';
 import * as SecureStore from 'src/storage/secure-store';
 
 import dbManager from 'src/storage/realm/dbManager';
@@ -45,7 +45,7 @@ import {
 
 import { RootState } from '../store';
 import { createWatcher } from '../utilities';
-import { fetchExchangeRates, fetchOneDayInsight } from '../sagaActions/send_and_receive';
+import { fetchExchangeRates } from '../sagaActions/send_and_receive';
 import { getMessages } from '../sagaActions/notifications';
 import { setLoginMethod } from '../reducers/settings';
 import { setWarning } from '../sagaActions/bhr';
@@ -53,7 +53,6 @@ import { uaiChecks } from '../sagaActions/uai';
 import { applyUpgradeSequence } from './upgrade';
 import { resetSyncing } from '../reducers/wallets';
 import { connectToNode } from '../sagaActions/network';
-import { createUaiMap } from '../reducers/uai';
 import SubScription from 'src/models/interfaces/Subscription';
 import { AppSubscriptionLevel, SubscriptionTier } from 'src/models/enums/SubscriptionTier';
 

--- a/src/store/sagas/network.ts
+++ b/src/store/sagas/network.ts
@@ -9,7 +9,7 @@ import {
 } from 'src/services/electrum/predefinedNodes';
 import ElectrumClient from 'src/services/electrum/client';
 import { captureError } from 'src/services/sentry';
-import { setDefaultNodesSaved } from '../reducers/network';
+import { setInitialNodesSaved } from '../reducers/network';
 import { RootState } from '../store';
 import {
   electrumClientConnectionExecuted,
@@ -24,24 +24,22 @@ export function* connectToNodeWorker() {
     console.log('Connecting to node...');
     yield put(electrumClientConnectionInitiated());
 
-    const savedDefaultNodes = yield call(dbManager.getCollection, RealmSchema.DefaultNodeConnect);
-    const areDefaultNodesSaved = yield select(
-      (state: RootState) => state.network.defaultNodesSaved
+    const areInitialNodesSaved = yield select(
+      (state: RootState) => state.network.initialNodesSaved
     );
+    const savedNodes = yield call(dbManager.getCollection, RealmSchema.NodeConnect);
 
-    if (!areDefaultNodesSaved && !savedDefaultNodes?.length) {
-      const hardcodedDefaultNodes =
+    if (!areInitialNodesSaved && !savedNodes?.length) {
+      const hardcodedInitialNodes =
         config.NETWORK_TYPE === NetworkType.TESTNET
           ? predefinedTestnetNodes
           : predefinedMainnetNodes;
-      dbManager.createObjectBulk(RealmSchema.DefaultNodeConnect, hardcodedDefaultNodes);
-      yield put(setDefaultNodesSaved(true));
+      dbManager.createObjectBulk(RealmSchema.NodeConnect, hardcodedInitialNodes);
+      yield put(setInitialNodesSaved(true));
     }
 
-    const defaultNodes =
-      config.NETWORK_TYPE === NetworkType.TESTNET ? predefinedTestnetNodes : predefinedMainnetNodes;
-    const privateNodes = yield call(dbManager.getCollection, RealmSchema.NodeConnect);
-    ElectrumClient.setActivePeer(defaultNodes, privateNodes);
+    const nodes = yield call(dbManager.getCollection, RealmSchema.NodeConnect);
+    ElectrumClient.setActivePeer(nodes);
     const { connected, connectedTo, error } = yield call(ElectrumClient.connect);
     if (connected) {
       yield put(electrumClientConnectionExecuted({ successful: connected, connectedTo }));

--- a/src/store/sagas/storage.ts
+++ b/src/store/sagas/storage.ts
@@ -7,7 +7,7 @@ import DeviceInfo from 'react-native-device-info';
 import { KeeperApp } from 'src/models/interfaces/KeeperApp';
 import { RealmSchema } from 'src/storage/realm/enum';
 import { AppSubscriptionLevel, SubscriptionTier } from 'src/models/enums/SubscriptionTier';
-import { NetworkType, WalletType } from 'src/services/wallets/enums';
+import { WalletType } from 'src/services/wallets/enums';
 import WalletUtilities from 'src/services/wallets/operations/utils';
 import crypto from 'crypto';
 import dbManager from 'src/storage/realm/dbManager';
@@ -70,13 +70,14 @@ export function* setupKeeperAppWorker({ payload }) {
         backup: {},
         version: DeviceInfo.getVersion(),
         networkType: config.NETWORK_TYPE,
+        enableAnalytics: false,
       };
       yield call(dbManager.createObject, RealmSchema.KeeperApp, newAPP);
 
       const defaultWallet: NewWalletInfo = {
         walletType: WalletType.DEFAULT,
         walletDetails: {
-          name: 'Wallet 1',
+          name: 'Mobile Wallet',
           description: '',
           transferPolicy: {
             id: uuidv4(),
@@ -134,6 +135,7 @@ function* setupKeeperVaultRecoveryAppWorker({ payload }) {
       },
       version: DeviceInfo.getVersion(),
       networkType: config.NETWORK_TYPE,
+      enableAnalytics: false,
     };
     yield call(dbManager.createObject, RealmSchema.KeeperApp, app);
 

--- a/tests/electrum-client/client.test.js
+++ b/tests/electrum-client/client.test.js
@@ -14,7 +14,7 @@ beforeAll(async () => {
   // awaiting for Electrum to be connected. For RN Electrum would naturally connect
   // while app starts up, but for tests we need to wait for it
   try {
-    ElectrumClient.setActivePeer(predefinedTestnetNodes, []);
+    ElectrumClient.setActivePeer(predefinedTestnetNodes);
     await ElectrumClient.connect();
     console.log('Electrum connected');
   } catch (err) {

--- a/tests/vault.test.ts
+++ b/tests/vault.test.ts
@@ -49,7 +49,7 @@ jest.setTimeout(20000);
 
 const connectToElectrumClient = async () => {
   try {
-    ElectrumClient.setActivePeer(predefinedTestnetNodes, []);
+    ElectrumClient.setActivePeer(predefinedTestnetNodes);
     await ElectrumClient.connect();
     console.log('Electrum connected');
   } catch (err) {

--- a/tests/wallet.test.ts
+++ b/tests/wallet.test.ts
@@ -20,7 +20,7 @@ describe('Wallet primitives', () => {
       'duty burger portion domain athlete sweet birth impact miss shield help peanut';
 
     try {
-      ElectrumClient.setActivePeer(predefinedTestnetNodes, []);
+      ElectrumClient.setActivePeer(predefinedTestnetNodes);
       await ElectrumClient.connect();
       // console.log('Electrum connected');
     } catch (err) {


### PR DESCRIPTION
Remove connection to defualt nodes. Now when the app is initially opened the initial nodes are saved, and the user can manage and remove these initial nodes. Also if the user is connected and the node doesn't work, the app will try any of the other nodes in the user's list. If the user disconnects from a node, the app will stay offline and prompt the user to select a node.  The modal of no connection to Electrum was also updated. 