### PR TITLE
fix: removed NDEF from prod entitlements ios

### DIFF
--- a/ios/hexa_keeper/hexa_keeper.entitlements
+++ b/ios/hexa_keeper/hexa_keeper.entitlements
@@ -18,7 +18,6 @@
 	</array>
 	<key>com.apple.developer.nfc.readersession.formats</key>
 	<array>
-		<string>NDEF</string>
 		<string>TAG</string>
 	</array>
 	<key>com.apple.developer.ubiquity-container-identifiers</key>


### PR DESCRIPTION
removed Ndef from ios prod entitlements to fix issue with uploading ipa to testlight.