### PR TITLE
Add: Relative Probability for Miniscript Policies

### DIFF
--- a/src/services/wallets/operations/miniscript/default/InheritanceVault.ts
+++ b/src/services/wallets/operations/miniscript/default/InheritanceVault.ts
@@ -78,12 +78,14 @@ export function generateInheritanceVaultElements(
       timelock: 0,
       paths: [{ id: 1, threshold: scheme.m, keys: keysInfo }],
       requiredPaths: 1,
+      probability: 9,
     },
     {
       id: 2,
       timelock,
       paths: [{ id: 1, threshold: scheme.m, keys: [...keysInfo, inheritanceKeyInfo] }],
       requiredPaths: 1,
+      probability: 1,
     },
   ];
 


### PR DESCRIPTION
This pull request enhances the Miniscript policy generation by introducing a probability parameter for each phase. Key changes include:

- Adding a probability field to the Phase interface.
- Modifying generateInheritanceVaultElements to include probability values.
- Updating policy-generator(introducing or fragment) to use the probability values for optimizing script generation.
