### PR TITLE
fix: removeApkCertVerifySteps

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -110,21 +110,6 @@ or
 gpg --keyserver hkps://keys.openpgp.org --recv-key "389F 4CAD A078 5AC0 E28A 0C18 1BEB DE26 1DC3 CF62"
 ```
 
-**Verify APK certificate**
-
-Rename `Android APK clone.apk` to `Android APK clone.zip` and extract the following file: `/META-INF/HEXAWALL.RSA`. Verify the certificate using `keytool`:
-
-```
-keytool -printcert -file HEXAWALLET.RSA
-Certificate fingerprints:
-	 ...
-	 MD5:  5E:92:30:9B:88:F4:A1:17:08:D1:DB:C3:2A:BF:4D:5A
-	 SHA1: 38:55:07:26:F4:C6:C4:3E:A2:87:CF:16:11:7C:E6:A5:66:E1:CB:C1
-	 SHA256: 77:82:54:70:5D:C4:DA:83:2C:F8:39:96:49:69:FE:AF:63:BD:79:EF:00:0A:34:43:86:0C:7C:AD:A2:55:1C:95
-	 Signature algorithm name: SHA256withRSA
-	 Version: 3
-```
-
 **Verify APK checksum**
 
 Verify the checksum against the APK using:
@@ -136,7 +121,7 @@ shasum -a 256 --check SHA256SUM.asc
 Output should contain the name of the APK file followed by **OK** as shown below:
 
 ```
-Bitcoin_Keeper_Beta_v1.1.8.apk: OK
+Bitcoin_Keeper_v2.0.0.apk: OK
 ```
 
 **Verify that the signed checksum is from hexa@bithyve.com**


### PR DESCRIPTION
Removed invalid apk certificate verification step.
/META-INF/HEXAWALL.RSA file was removed with introduction of APK Signature Scheme v2.