### PR TITLE
KeeperPrivateUi issues and ServerKey Restriction

### DIFF
--- a/src/hooks/useSettingKeeper.tsx
+++ b/src/hooks/useSettingKeeper.tsx
@@ -65,7 +65,7 @@ export const useSettingKeeper = () => {
   const navigation = useNavigation();
   const { showToast } = useToastMessage();
   const isFocused = useIsFocused();
-  const { isOnL2Above } = usePlan();
+  const { isOnL2Above, isOnL4 } = usePlan();
 
   const data = useQuery(RealmSchema.BackupHistory);
   const [confirmPass, setConfirmPass] = useState(false);
@@ -230,7 +230,7 @@ export const useSettingKeeper = () => {
   ];
 
   const General = [
-    {
+    !isOnL4 && {
       title: settings.DarkMode,
       description: settings.DarkModeSubTitle,
       icon: <DarkModeIcon width={14} height={14} />,
@@ -259,7 +259,7 @@ export const useSettingKeeper = () => {
       onPress: () => navigation.navigate('SettingApp'),
       isDiamond: false,
     },
-  ];
+  ].filter(Boolean);
   const keysAndwallet = [
     {
       title: common.manageKeys,

--- a/src/screens/KeeperConcierge/components/AccountManagerCard.tsx
+++ b/src/screens/KeeperConcierge/components/AccountManagerCard.tsx
@@ -40,11 +40,15 @@ export const AccountManagerCard = ({ data }) => {
   const { colorMode } = useColorMode();
 
   return (
-    <Box style={{ flex: 1, width: screenWidth, paddingHorizontal: wp(20), marginTop: hp(30) }}>
+    <Box style={styles.container}>
       <Text medium fontSize={14}>
         Account Manager
       </Text>
-      <Box style={styles.cardCtr} backgroundColor={`${colorMode}.seashellWhite`}>
+      <Box
+        style={styles.cardCtr}
+        backgroundColor={`${colorMode}.seashellWhite`}
+        borderColor={`${colorMode}.separator`}
+      >
         <Box style={styles.profileCtr}>
           <Image
             style={styles.image}
@@ -60,7 +64,11 @@ export const AccountManagerCard = ({ data }) => {
           {Object.entries(data.links).map(([key, value]: [string, string]) => {
             return (
               <TouchableOpacity key={key} onPress={() => Linking.openURL(value)}>
-                <Box style={styles.linkBox} borderColor={`${colorMode}.dullGreyBorder`}>
+                <Box
+                  style={styles.linkBox}
+                  borderColor={`${colorMode}.dullGreyBorder`}
+                  backgroundColor={`${colorMode}.primaryBackground`}
+                >
                   {ICON_MAP[colorMode][key]}
                   <Text fontSize={12}>{capitalizeEachWord(key)}</Text>
                 </Box>
@@ -74,6 +82,11 @@ export const AccountManagerCard = ({ data }) => {
 };
 
 const styles = StyleSheet.create({
+  container: {
+    width: screenWidth,
+    paddingHorizontal: wp(20),
+    marginTop: hp(30),
+  },
   linkBox: {
     flexDirection: 'column',
     borderWidth: 1,
@@ -101,5 +114,6 @@ const styles = StyleSheet.create({
     marginTop: hp(12),
     padding: wp(15),
     borderRadius: wp(10),
+    borderWidth: 1,
   },
 });

--- a/src/screens/Vault/SignerAdvanceSettings.tsx
+++ b/src/screens/Vault/SignerAdvanceSettings.tsx
@@ -112,6 +112,7 @@ function SignerAdvanceSettings({ route }: any) {
   } = route.params;
   const { signerMap } = useSignerMap();
   const { signers } = useSigners();
+  const { isOnL4 } = usePlan();
 
   const signer: Signer = signerFromParam
     ? signers.find((signer) => getKeyUID(signer) === getKeyUID(signerFromParam)) // to reflect associated contact image in real time
@@ -649,8 +650,6 @@ function SignerAdvanceSettings({ route }: any) {
     );
   }, []);
 
-  const [upgradeAdditionalUser, setUpgradeAdditionalUser] = useState(true);
-
   const displayedCards = [
     !isMobileKey && (
       <OptionCard
@@ -762,17 +761,14 @@ function SignerAdvanceSettings({ route }: any) {
         title="Additional Users"
         description="Add multiple users for the Server Key"
         callback={() => {
-          if (!upgradeAdditionalUser) {
-            navigation.navigate('AdditionalUsers', { vaultKey });
-          }
+          isOnL4 && navigation.navigate('AdditionalUsers', { vaultKey });
         }}
-        disabled={upgradeAdditionalUser}
+        disabled={!isOnL4}
         rightComponent={
-          upgradeAdditionalUser &&
+          !isOnL4 &&
           (() => {
             return (
-              // this will be upgraded with private subscription but for now it is handeling with state
-              <TouchableOpacity onPress={() => setUpgradeAdditionalUser(false)}>
+              <TouchableOpacity onPress={() => navigation.navigate('ChoosePlan')}>
                 <UpgradeIcon style={styles.upgradeIcon} width={64} height={20} />
               </TouchableOpacity>
             );


### PR DESCRIPTION
Hides dark mode toggle on keeper private subscription
Fixes account manager card ui for light theme
Addressing https://github.com/bithyve/bitcoin-keeper/issues/6292