### PR TITLE
Fixes migration issues and tapsigner assign signer type

### DIFF
--- a/src/screens/Vault/AssignSignerType.tsx
+++ b/src/screens/Vault/AssignSignerType.tsx
@@ -49,6 +49,7 @@ function AssignSignerType({ route }: IProps) {
   const navigation = useNavigation();
   const [goBackSuccessMessage, setGoBackSuccessMessage] = useState('');
   const [goBackErrorMessage, setGoBackErrorMessage] = useState('');
+  const isUnknownSigner = signer.type === SignerType.UNKOWN_SIGNER;
 
   useEffect(() => {
     if (relaySignersUpdate) {
@@ -84,7 +85,8 @@ function AssignSignerType({ route }: IProps) {
     SignerType.TREZOR,
     SignerType.SEED_WORDS,
     SignerType.POLICY_SERVER,
-  ];
+    isUnknownSigner && SignerType.TAPSIGNER,
+  ].filter(Boolean);
 
   const [isNfcSupported, setNfcSupport] = useState(true);
   const [signersLoaded, setSignersLoaded] = useState(false);
@@ -110,7 +112,7 @@ function AssignSignerType({ route }: IProps) {
         subTitle={signerText.changeSignerSubtitle}
       />
       <ScrollView contentContainerStyle={styles.container} showsVerticalScrollIndicator={false}>
-        {signer.type === SignerType.UNKOWN_SIGNER && <UnknownSignerInfo signer={signer} />}
+        {isUnknownSigner && <UnknownSignerInfo signer={signer} />}
         {!signersLoaded ? (
           <ActivityIndicator />
         ) : (

--- a/src/storage/realm/migrations.ts
+++ b/src/storage/realm/migrations.ts
@@ -420,8 +420,8 @@ export const runRealmMigrations = ({
       const oldWallet = oldWallets[i];
       const { specs: oldSpecs } = oldWallet;
       const { specs: newSpecs } = newWallet;
-      newSpecs.addresses = { ...oldSpecs?.addresses };
-      newSpecs.addressPubs = { ...oldSpecs?.addressPubs };
+      newSpecs.addresses = oldSpecs?.addresses ? { ...oldSpecs.addresses } : null;
+      newSpecs.addressPubs = oldSpecs?.addressPubs ? { ...oldSpecs?.addressPubs } : null;
       newSpecs.balances = {
         confirmed: oldSpecs.balances?.confirmed ?? 0,
         unconfirmed: oldSpecs.balances?.unconfirmed ?? 0,

--- a/src/storage/realm/migrations.ts
+++ b/src/storage/realm/migrations.ts
@@ -420,8 +420,8 @@ export const runRealmMigrations = ({
       const oldWallet = oldWallets[i];
       const { specs: oldSpecs } = oldWallet;
       const { specs: newSpecs } = newWallet;
-      newSpecs.addresses = oldSpecs.addresses ?? null;
-      newSpecs.addressPubs = oldSpecs.addressPubs ?? null;
+      newSpecs.addresses = { ...oldSpecs?.addresses };
+      newSpecs.addressPubs = { ...oldSpecs?.addressPubs };
       newSpecs.balances = {
         confirmed: oldSpecs.balances?.confirmed ?? 0,
         unconfirmed: oldSpecs.balances?.unconfirmed ?? 0,
@@ -433,8 +433,8 @@ export const runRealmMigrations = ({
       const oldVault = oldVaults[i];
       const { specs: oldSpecs } = oldVault;
       const { specs: newSpecs } = newVault;
-      newSpecs.addresses = oldSpecs.addresses;
-      newSpecs.addressPubs = oldSpecs.addressPubs;
+      newSpecs.addresses = { ...oldSpecs?.addresses };
+      newSpecs.addressPubs = { ...oldSpecs?.addressPubs };
       newSpecs.balances = {
         confirmed: oldSpecs.balances?.confirmed ?? 0,
         unconfirmed: oldSpecs.balances?.unconfirmed ?? 0,
@@ -443,7 +443,9 @@ export const runRealmMigrations = ({
       if (newVault.type === VaultType.MINISCRIPT) {
         const { miniscriptScheme: oldMiniscriptScheme } = oldVault.scheme;
         const { miniscriptScheme: newMiniscriptScheme } = newVault.scheme;
-        newMiniscriptScheme.keyInfoMap = oldMiniscriptScheme?.keyInfoMap || null;
+        newMiniscriptScheme.keyInfoMap = oldMiniscriptScheme?.keyInfoMap
+          ? { ...oldMiniscriptScheme?.keyInfoMap }
+          : null;
         newMiniscriptScheme.miniscriptElements = {
           ...oldMiniscriptScheme.miniscriptElements,
           signerFingerprints: oldMiniscriptScheme.miniscriptElements.signerFingerprints,


### PR DESCRIPTION
Fixes
- Missing miniscript vault data in migration. 
- Wallet sync error due to migration failure.
- Added TapSigner in assign signer type list for unknown signers.
