### PR TITLE
Fix multisig descriptor detection

### DIFF
--- a/src/utils/service-utilities/utils.ts
+++ b/src/utils/service-utilities/utils.ts
@@ -331,7 +331,7 @@ export const parseTextforVaultConfig = (secret: string) => {
     };
     return parsedResponse;
   }
-  if (!config && secret.indexOf('sortedmulti(')) {
+  if (!config && secret.includes('sortedmulti(')) {
     config = { descriptor: secret, label: 'Multisig vault' };
   }
   if (secret.indexOf('sortedmulti(') !== -1 && config.descriptor) {


### PR DESCRIPTION
## Summary
- ensure `parseTextforVaultConfig` detects multisig descriptors when they contain `sortedmulti(`

## Testing
- `npm test` *(fails: jest not found)*
- `npm run lint` *(fails: ESLint couldn't find config)*

------
https://chatgpt.com/codex/tasks/task_e_6846a701a0748323b41d1aa824ba33d3