### PR TITLE
Clean android network security domains 

### DIFF
--- a/android/app/src/main/res/xml/network_security_config.xml
+++ b/android/app/src/main/res/xml/network_security_config.xml
@@ -11,9 +11,6 @@
         <domain includeSubdomains="true">10.0.2.2</domain>
         <domain includeSubdomains="true">10.0.3.2</domain>
         <domain includeSubdomains="true">bithyve.com</domain>
-        <domain includeSubdomains="true">hexawallet.io</domain>
-        <domain includeSubdomains="true">fastbitcoins.com</domain>
         <domain includeSubdomains="true">ramp.network</domain>
-        <domain includeSubdomains="true">swanbitcoin.com</domain>
     </domain-config>
 </network-security-config>


### PR DESCRIPTION
Removed sub-domains from android network security config which are no longer utilised.