### PR TITLE
Fixes psbt validation error

### DIFF
--- a/src/utils/utilities.ts
+++ b/src/utils/utilities.ts
@@ -869,8 +869,11 @@ export const manipulateBitcoinPrices = (data) => {
 };
 
 export const validatePSBT = (unsigned, signed, signer, errorText) => {
-  // TODO: Need conditional check for TapSigner and Specter psbt
-  if ([SignerType.TAPSIGNER, SignerType.SPECTER, SignerType.SEEDSIGNER].includes(signer.type))
+  if (
+    [SignerType.TAPSIGNER, SignerType.SPECTER, SignerType.SEEDSIGNER, SignerType.KRUX].includes(
+      signer.type
+    )
+  )
     return;
   const unsignedHex = bitcoin.Psbt.fromBase64(unsigned).__CACHE.__TX.toHex();
   const signedPsbtObj = bitcoin.Psbt.fromBase64(signed);
@@ -879,12 +882,7 @@ export const validatePSBT = (unsigned, signed, signer, errorText) => {
     throw new Error(errorText.psbtNotMatch);
   }
   let signerPublicKey;
-  try {
-    signerPublicKey = getInputsToSignFromPSBT(signed, signer).map((data) => data.publicKey)[0];
-  } catch (error) {
-    console.log('🚀 ~ validatePSBT ~ error:', error);
-    return;
-  }
+  signerPublicKey = getInputsToSignFromPSBT(unsigned, signer).map((data) => data.publicKey)[0];
   let isSigned = false;
   const validator = (pubkey: Buffer, msghash: Buffer, signature: Buffer): boolean =>
     ECPair.fromPublicKey(pubkey).verify(msghash, signature);

--- a/src/utils/utilities.ts
+++ b/src/utils/utilities.ts
@@ -870,14 +870,21 @@ export const manipulateBitcoinPrices = (data) => {
 
 export const validatePSBT = (unsigned, signed, signer, errorText) => {
   // TODO: Need conditional check for TapSigner and Specter psbt
-  if ([SignerType.TAPSIGNER, SignerType.SPECTER].includes(signer.type)) return;
+  if ([SignerType.TAPSIGNER, SignerType.SPECTER, SignerType.SEEDSIGNER].includes(signer.type))
+    return;
   const unsignedHex = bitcoin.Psbt.fromBase64(unsigned).__CACHE.__TX.toHex();
   const signedPsbtObj = bitcoin.Psbt.fromBase64(signed);
   const signedHex = signedPsbtObj.__CACHE.__TX.toHex();
   if (signedHex !== unsignedHex) {
     throw new Error(errorText.psbtNotMatch);
   }
-  const signerPublicKey = getInputsToSignFromPSBT(signed, signer).map((data) => data.publicKey)[0];
+  let signerPublicKey;
+  try {
+    signerPublicKey = getInputsToSignFromPSBT(signed, signer).map((data) => data.publicKey)[0];
+  } catch (error) {
+    console.log('🚀 ~ validatePSBT ~ error:', error);
+    return;
+  }
   let isSigned = false;
   const validator = (pubkey: Buffer, msghash: Buffer, signature: Buffer): boolean =>
     ECPair.fromPublicKey(pubkey).verify(msghash, signature);


### PR DESCRIPTION
Skips PSBY validation in case of missing bip32derivation object in PSBT input.
Addressing Error When Scanning SeedSigner and Krux QR in Keeper: Cannot read property 'forEach' of undefined. #6833
