### PR TITLE
Update satochip-react-native library to v0.1.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -118,7 +118,7 @@
     "redux-persist": "6.0.0",
     "redux-saga": "1.1.3",
     "rn-qr-generator": "^1.4.4",
-    "satochip-react-native": "git+https://github.com/Toporin/satochip-react-native.git#7ce6606613ab8d244e3d0ace56d57d11c141e480",
+    "satochip-react-native": "git+https://github.com/Toporin/satochip-react-native.git#1076e7c097571d561b5b903f31c6337455def19e",
     "semver": "7.3.8",
     "socket.io-client": "4.5.4",
     "stream": "0.0.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -10657,9 +10657,9 @@ safe-regex-test@^1.0.3, safe-regex-test@^1.1.0:
   resolved "https://registry.yarnpkg.com/safer-buffer/-/safer-buffer-2.1.2.tgz#44fa161b0187b9549dd84bb91802f9bd8385cd6a"
   integrity sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==
 
-"satochip-react-native@git+https://github.com/Toporin/satochip-react-native.git#7ce6606613ab8d244e3d0ace56d57d11c141e480":
-  version "0.1.3"
-  resolved "git+https://github.com/Toporin/satochip-react-native.git#7ce6606613ab8d244e3d0ace56d57d11c141e480"
+"satochip-react-native@git+https://github.com/Toporin/satochip-react-native.git#1076e7c097571d561b5b903f31c6337455def19e":
+  version "0.1.4"
+  resolved "git+https://github.com/Toporin/satochip-react-native.git#1076e7c097571d561b5b903f31c6337455def19e"
   dependencies:
     asn1js "^3.0.6"
     bech32 "2.0.0"


### PR DESCRIPTION
Fix public key recovery from signature for edge case where most significant byte of pubkey x-coordinate is zero.

See satochip-react-native patch here: https://github.com/Toporin/satochip-react-native/commit/1076e7c097571d561b5b903f31c6337455def19e

Fixes KeeperCommunity/bitcoin-keeper#6914