### PR TITLE
Enhance UTXO management with spendability(dust attack protection) and donation features

### DIFF
--- a/openspec/changes/dust-attack-protection-and-donate-dust-v2/.openspec.yaml
+++ b/openspec/changes/dust-attack-protection-and-donate-dust-v2/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-05-15

--- a/openspec/changes/dust-attack-protection-and-donate-dust-v2/design.md
+++ b/openspec/changes/dust-attack-protection-and-donate-dust-v2/design.md
@@ -1,0 +1,116 @@
+## Context
+
+This change introduces privacy-focused dust attack protection across wallet sync, UTXO management, send flow, and transaction history, while keeping existing Keeper navigation and screen architecture. Current UTXO objects (`Wallet.specs.confirmedUTXOs` / `unconfirmedUTXOs`) have no persisted spendability status, so automatic coin selection can include suspicious low-value UTXOs. The selected approach is Option A: extend persisted UTXO metadata in Realm so each current wallet-owned UTXO has an explicit spendability state and reason, with user override support.
+
+Stakeholders include wallet users (privacy safety), transaction/signing flows (software + hardware signers), and sync/storage integrity (Realm migration and refresh performance). The change affects both mainnet and testnet UTXO classification behavior.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Persist UTXO spendability state (`Spendable` or `Do Not Spend`) plus reason and override.
+- Classify UTXOs during existing sync/refresh points without adding a new dashboard screen.
+- Use sats-only detection: `< 5000` sats + address-reuse/out-of-order rule.
+- Trace already-spent potential dust descendants one level deep for this release.
+- Exclude Do Not Spend UTXOs from automatic send input selection and spendable balance.
+- Provide manual state controls and reasons in existing UTXO screens.
+- Keep existing PSBT signing flow compatible for Wallet, Vault, and Signer interactions.
+- Include Donate Dust flow using only Do Not Spend UTXOs and minimum fee rate.
+
+**Non-Goals:**
+- Multi-level risk scoring or pattern-based mass-dusting analytics.
+- Full recursive descendant tracing beyond one level.
+- Out-of-order detection rules for change addresses.
+- New subscription gating or tier-specific behavior.
+- New standalone dust management screens.
+
+## Decisions
+
+1. **Use Option A persisted metadata in Realm (`UTXOInfo`)**
+- Decision: extend `UTXOInfo` with spendability fields (`spendability`, `reason`, `isUserOverride`, optional `toastShownAt` or equivalent marker).
+- Rationale: explicit domain model, queryable by wallet, robust override persistence.
+- Alternative considered: system labels-only approach in `Tags`; rejected because override semantics and efficient querying become implicit and brittle.
+
+2. **Classification runs in wallet sync pipeline, not in UI layer**
+- Decision: compute/assign spendability during `WalletOperations.syncWalletsViaElectrumClient` result handling in wallet refresh saga path.
+- Rationale: single source of truth and consistent behavior across wallet create/import/restore/post-upgrade open/pull-refresh.
+- Alternative considered: classify on demand in each UI screen; rejected due to inconsistency and repeated logic.
+
+3. **Address metadata uses lightweight wallet-scoped cache**
+- Decision: derive and persist per-wallet address receive metadata needed for reused/out-of-order checks (receive + change), using existing address index knowledge and transaction refresh outputs.
+- Rationale: avoids repeated full-history scans and keeps classification bounded.
+- Alternative considered: recompute from full history each refresh; rejected due to avoidable cost.
+
+4. **One-level descendant tracing for already-spent potential dust**
+- Decision: detect historical potential-dust spends and mark traceable currently-owned direct descendants as `Do Not Spend` with reason `Linked to potential dust spend`.
+- Rationale: aligns with current scope and complexity budget.
+- Alternative considered: recursive multi-level graph traversal; deferred.
+
+5. **Coin selection enforcement at transaction preparation layer**
+- Decision: filter default input pools in `calculateSendMaxFee`, `prepareTransactionPrerequisites`, and `prepareCustomTransactionPrerequisites` to exclude Do Not Spend unless user explicitly selected UTXOs.
+- Rationale: guarantees automatic send exclusions regardless of UI entry path.
+- Alternative considered: UI-only filtering; rejected because backend selection paths can still include restricted UTXOs.
+
+6. **Donate Dust in scope with strict input-source rules**
+- Decision: add Donate Dust action in Manage Coins using only current Do Not Spend UTXOs, paying fees only from those UTXOs, minimum fee rate, and donation destination `bc1qyqequr0824nwf7snzvq5gqsr6xscn62e3ttm06`.
+- Rationale: allows privacy cleanup without mixing spendable coins.
+- Failure behavior: if no valid tx can be built from selected Do Not Spend UTXOs alone, keep state unchanged and show required error copy.
+
+7. **UI follows existing DESIGN.md primitives and patterns**
+- Decision: reuse existing red-dot indicator, UTXO label chip, warning text style, bottom sheets/modals, and toast components.
+- DESIGN.md alignment:
+  - calm warning tone, no panic copy
+  - existing tokens/surfaces and component patterns
+  - no new visual language or dashboard
+  - security-relevant copy untruncated
+- New component need: none required; only state/copy wiring into existing components.
+
+8. **Hardware/PSBT compatibility preserved**
+- Decision: dust protection modifies eligible inputs but does not modify PSBT format, signing algorithm, or signer protocol.
+- Data flow impact for signing:
+  - Wallet/Vault UTXOs -> filtered prerequisites -> PSBT construction -> existing Signer(s) sign path unchanged.
+
+## Risks / Trade-offs
+
+- **[Risk] False positives from address-reuse heuristics** -> Mitigation: explicit `Mark Spendable` override and persistence to prevent re-marking after override.
+- **[Risk] Sync-time performance regressions** -> Mitigation: lightweight metadata persistence and incremental classification only for UTXOs without state.
+- **[Risk] State drift between UTXO set and metadata records** -> Mitigation: upsert by `txId:vout`, prune/ignore absent UTXOs during refresh, and keep classification in one pipeline.
+- **[Risk] Donation tx build failures for tiny sets** -> Mitigation: deterministic validation and explicit user-facing failure copy; no fallback to spendable inputs.
+- **[Risk] UX confusion around total vs spendable balance** -> Mitigation: helper copy in send flow only when mismatch condition occurs.
+
+## Migration Plan
+
+1. Add new fields to Realm `UTXOInfo` schema and bump Realm schema version (currently 106 -> next version).
+2. Add migration logic in `src/storage/realm/migrations.ts` to initialize new fields for existing rows.
+3. During post-upgrade wallet refresh, classify UTXOs that lack spendability state; preserve any existing user override.
+4. No Redux Persist version bump in `src/store/migrations.ts` is required unless store shape changes are introduced later.
+5. Rollback strategy: keep migration additive/nullable so old states degrade to default `Spendable` behavior if feature flags or code paths are disabled.
+
+## Affected Files (Planned)
+
+- `src/services/wallets/interfaces/index.ts` (UTXO/UTXOInfo type additions)
+- `src/storage/realm/schema/wallet.ts` (UTXOInfo schema extension)
+- `src/storage/realm/realm.ts` (schema version bump)
+- `src/storage/realm/migrations.ts` (migration for new fields)
+- `src/services/wallets/operations/index.ts` (classification metadata + send input filtering + donation prerequisites)
+- `src/store/sagas/wallets.ts` (classification persistence, one-time dust toast trigger)
+- `src/store/sagaActions/utxos.ts` and `src/store/sagas/utxos.ts` (manual mark actions persistence if needed)
+- `src/screens/UTXOManagement/UTXOManagement.tsx` and UTXO components (labels, Donate Dust CTA)
+- `src/screens/Send/AddSendAmount.tsx` and related send screens (spendable-vs-total helper messaging)
+- `src/screens/WalletDetails/*` and home wallet card components (red-dot/subtitle indicators)
+- `src/screens/ViewTransactions/*` (Potential dust spend informational tag/detail)
+- `src/navigation/types.ts` and related screen params if new modal routes are added
+- Tests under `tests/` and/or feature-specific test files for classification, filtering, overrides, and donation failures
+
+## Open Questions
+
+- For testnet, should Donate Dust be hidden or allowed with fallback handling when donation address is mainnet-only?
+- Should one-time dust toast suppression be persisted as an explicit field or inferred from first-time Do Not Spend transition?
+- Should manual selection warning for Do Not Spend be implemented as modal or bottom sheet in current mobile layout patterns?
+
+## DESIGN.md Checklist Confirmation
+
+- Existing component reuse prioritized: Yes.
+- Existing tokens and warning patterns respected: Yes.
+- No new visual language introduced: Yes.
+- Security/privacy copy remains concise and clear: Yes.
+- UI remains consistent with current Keeper structure: Yes.

--- a/openspec/changes/dust-attack-protection-and-donate-dust-v2/proposal.md
+++ b/openspec/changes/dust-attack-protection-and-donate-dust-v2/proposal.md
@@ -1,0 +1,48 @@
+## Why
+
+Keeper currently treats all wallet UTXOs as spendable by default, so suspicious low-value UTXOs can be auto-selected in normal sends and reduce user privacy by linking coins. This change adds first-version dust attack protection now because Keeper already has coin-control surfaces and can deliver protection without introducing a new screen model.
+
+## What Changes
+
+- Add persisted UTXO spendability state with two values: Spendable and Do Not Spend.
+- Use Option A storage model: extend persisted UTXO metadata to store spendability status, reason, and user override.
+- Classify UTXOs during wallet scan/refresh flows (create, import/restore, post-upgrade open, pull-to-refresh, incoming scan) using sats-only rules.
+- Mark potential dust UTXOs as Do Not Spend when value is below 5,000 sats and address reuse/out-of-order rules match.
+- Preserve explicit user overrides so marked-spendable coins are not auto-re-marked on next scan.
+- Detect already-spent potential dust and trace affected descendants one level deep for this version, marking current traceable descendants as Do Not Spend.
+- Exclude Do Not Spend UTXOs from normal automatic coin selection and available-to-spend calculations.
+- Add send-flow helper messaging when total balance is enough but spendable balance is insufficient due to Do Not Spend state.
+- Add manual controls in UTXO details: Mark Do Not Spend and Mark Spendable with reason visibility.
+- Add wallet-level visual indicators (red dots and wallet detail subtitle line) based on presence of current Do Not Spend coins.
+- Add transaction history/detail informational tagging for Potential dust spend events.
+- Add Donate Dust flow in scope: build donation transaction from Do Not Spend UTXOs only, pay fees from those UTXOs only, minimum fee rate, and donate remainder to configured address.
+- Affect both mainnet and testnet behavior for dust classification and Do Not Spend handling; donation destination remains the specified mainnet donation address.
+- Hardware signer compatibility: no new signing protocol; flows must remain compatible with existing PSBT signing across software and hardware signers.
+- Subscription tier gating: no additional tier gate introduced; feature follows current wallet/coin-control availability.
+
+## Non-goals
+
+- Multi-level dust risk scoring.
+- Mass-dusting transaction-pattern analytics.
+- Out-of-order detection rules for change addresses.
+- General economic dust cleanup beyond privacy-focused Do Not Spend handling.
+- Deep recursive descendant tracing beyond one level in this version.
+- New standalone dust dashboard or dedicated dust screen.
+
+## Capabilities
+
+### New Capabilities
+- `dust-attack-protection`: end-to-end Do Not Spend classification, visibility, overrides, and donation flow for potential dust privacy protection.
+
+### Modified Capabilities
+- `utxo-management`: add spendability state UX, reason visibility, manual state toggles, and donation entry points in existing coin-control surfaces.
+- `send-and-receive`: exclude Do Not Spend from default input selection and available balance; add insufficient-spendable helper behavior.
+- `wallets`: include wallet-level red-dot and subtitle indicators derived from Do Not Spend UTXO presence during refresh/sync.
+- `transaction-history`: add informational Potential dust spend labeling and detail explanation for identified historical spends.
+
+## Impact
+
+- Affected systems: wallet sync/classification pipeline, coin selection and fee prep, UTXO management UI, send flow UI logic, wallet list/detail indicators, transaction history metadata.
+- Storage: Realm schema change required for Option A persisted UTXO spendability metadata and migration updates.
+- Security/privacy impact: reduces unintended privacy linkage risk by preventing automatic spending of suspicious UTXOs; no new key-material handling; no new external network dependencies beyond existing wallet sync calls.
+- APIs/dependencies: existing transaction construction and PSBT flows reused; no new third-party dependency required for core behavior.

--- a/openspec/changes/dust-attack-protection-and-donate-dust-v2/specs/dust-attack-protection/spec.md
+++ b/openspec/changes/dust-attack-protection-and-donate-dust-v2/specs/dust-attack-protection/spec.md
@@ -1,0 +1,50 @@
+## ADDED Requirements
+
+### Requirement: UTXO spendability classification and persistence
+The system SHALL persist a spendability state for each current wallet-owned `UTXO` in `Wallet` or `Vault` as either `Spendable` or `Do Not Spend`, including a reason and user override marker.
+
+#### Scenario: Classify new receive-address dust
+- **GIVEN** a wallet refresh identifies a new `UTXO` worth 4,999 satoshis on a receive address that has received before
+- **WHEN** classification runs during sync
+- **THEN** the `UTXO` SHALL be persisted as `Do Not Spend` with reason `Potential dust payment`
+
+#### Scenario: Classify out-of-order receive-address dust
+- **GIVEN** a wallet refresh identifies a new `UTXO` worth 4,000 satoshis on receive address index 2 while highest received receive index is 7
+- **WHEN** classification runs during sync
+- **THEN** the `UTXO` SHALL be persisted as `Do Not Spend` with reason `Potential dust payment`
+
+#### Scenario: Do not classify non-dust by value
+- **GIVEN** a new `UTXO` worth 5,000 satoshis or more on any address
+- **WHEN** classification runs during sync
+- **THEN** the `UTXO` SHALL be persisted as `Spendable`
+
+#### Scenario: Preserve user override
+- **GIVEN** a `UTXO` is marked spendable by user override
+- **WHEN** subsequent refresh classification runs
+- **THEN** the same `UTXO` SHALL remain `Spendable` unless user changes it again
+
+### Requirement: Already-spent dust descendant handling (one level)
+The system SHALL identify historical potential dust spends and mark traceable current wallet-owned one-level descendants as `Do Not Spend`.
+
+#### Scenario: Mark one-level descendants
+- **GIVEN** a historical potential-dust `UTXO` has been spent and one direct output descendant is currently owned by the same `Wallet`
+- **WHEN** dust spend tracing runs
+- **THEN** the descendant `UTXO` SHALL be marked `Do Not Spend` with reason `Linked to potential dust spend`
+
+#### Scenario: Out-of-scope deeper descendants
+- **GIVEN** a potential-dust lineage has descendants beyond one transaction hop
+- **WHEN** tracing runs in this version
+- **THEN** only direct descendants SHALL be considered for automatic marking
+
+### Requirement: Dust detection one-time notification
+The system SHALL show a one-time informational toast for newly detected potential dust during normal refresh scans.
+
+#### Scenario: Show one-time toast for new dust
+- **GIVEN** refresh detects a newly classified `Do Not Spend` `UTXO` with reason `Potential dust payment`
+- **WHEN** the wallet is in normal post-import runtime refresh
+- **THEN** the app SHALL show `Potential dust payment found` exactly once for that `UTXO`
+
+#### Scenario: Suppress repeated toast
+- **GIVEN** the same potential dust `UTXO` is seen in later refreshes
+- **WHEN** classification runs again
+- **THEN** no additional dust toast SHALL be shown for that `UTXO`

--- a/openspec/changes/dust-attack-protection-and-donate-dust-v2/specs/send-and-receive/spec.md
+++ b/openspec/changes/dust-attack-protection-and-donate-dust-v2/specs/send-and-receive/spec.md
@@ -1,0 +1,27 @@
+## ADDED Requirements
+
+### Requirement: Automatic send input exclusion for Do Not Spend
+Automatic input selection SHALL exclude all `UTXO` entries marked `Do Not Spend`.
+
+#### Scenario: Exclude Do Not Spend from default selection
+- **GIVEN** a `Wallet` has 20,000 satoshis total and 6,000 satoshis are in `Do Not Spend` `UTXO` entries
+- **WHEN** user starts normal send without manual `selectedUTXOs`
+- **THEN** transaction prerequisite input selection SHALL consider only 14,000 spendable satoshis
+
+#### Scenario: Manual selection warning for Do Not Spend
+- **GIVEN** user is in manual coin selection and taps a `Do Not Spend` `UTXO`
+- **WHEN** selection action is attempted
+- **THEN** app SHALL require explicit confirmation before including that `UTXO`
+
+### Requirement: Spendable-balance aware send messaging
+The send flow SHALL explain insufficient spendable balance when total balance is sufficient.
+
+#### Scenario: Total sufficient but spendable insufficient
+- **GIVEN** total wallet balance is 50,000 satoshis and spendable balance is 30,000 satoshis
+- **WHEN** user attempts to send 40,000 satoshis
+- **THEN** send flow SHALL show `Some coins are marked Do Not Spend and are not available for this payment.`
+
+#### Scenario: Standard insufficient balance behavior
+- **GIVEN** spendable balance is less than requested amount and total balance is also less than requested amount
+- **WHEN** user attempts send
+- **THEN** existing insufficient balance behavior SHALL remain unchanged

--- a/openspec/changes/dust-attack-protection-and-donate-dust-v2/specs/transaction-history/spec.md
+++ b/openspec/changes/dust-attack-protection-and-donate-dust-v2/specs/transaction-history/spec.md
@@ -1,0 +1,19 @@
+## ADDED Requirements
+
+### Requirement: Historical potential dust spend labeling
+Transaction history SHALL mark transactions that spent potential-dust inputs.
+
+#### Scenario: Label historical dust spend
+- **GIVEN** a historical transaction spent an input that matches potential-dust rules (`UTXO` value below 5,000 satoshis plus qualifying address condition)
+- **WHEN** transaction history renders that entry
+- **THEN** transaction SHALL display `Potential dust spend`
+
+#### Scenario: Detail explanation for privacy impact
+- **GIVEN** user opens a transaction labeled `Potential dust spend`
+- **WHEN** transaction detail screen is shown
+- **THEN** the screen SHALL display `This transaction may have spent a suspicious small amount together with other wallet funds. This may have reduced wallet privacy.`
+
+#### Scenario: No wallet red-dot from historical-only event
+- **GIVEN** wallet has historical `Potential dust spend` records but no current `Do Not Spend` UTXOs
+- **WHEN** wallet list is rendered
+- **THEN** wallet-level red-dot indicator SHALL not be shown based on historical-only events

--- a/openspec/changes/dust-attack-protection-and-donate-dust-v2/specs/utxo-management/spec.md
+++ b/openspec/changes/dust-attack-protection-and-donate-dust-v2/specs/utxo-management/spec.md
@@ -1,0 +1,45 @@
+## ADDED Requirements
+
+### Requirement: UTXO details manual spendability control
+The UTXO details flow SHALL allow explicit spendability control for each wallet-owned `UTXO`.
+
+#### Scenario: Mark Do Not Spend manually
+- **GIVEN** a `UTXO` currently marked `Spendable`
+- **WHEN** user taps `Mark Do Not Spend`
+- **THEN** the `UTXO` SHALL persist as `Do Not Spend` with reason `Marked manually`
+
+#### Scenario: Mark Spendable manually
+- **GIVEN** a `UTXO` currently marked `Do Not Spend`
+- **WHEN** user taps `Mark Spendable`
+- **THEN** the `UTXO` SHALL persist as `Spendable` with user override enabled
+
+### Requirement: Do Not Spend visibility in coin list
+Manage Coins SHALL visibly label Do Not Spend coins while preserving existing labels.
+
+#### Scenario: Show warning-style Do Not Spend label
+- **GIVEN** Manage Coins displays a list of `UTXO` entries
+- **WHEN** a row represents a `UTXO` marked `Do Not Spend`
+- **THEN** the row SHALL show `Do Not Spend` using existing warning-style label treatment
+
+#### Scenario: Preserve existing label stack
+- **GIVEN** a `UTXO` has existing labels such as `Change` or `Self`
+- **WHEN** the same `UTXO` is marked `Do Not Spend`
+- **THEN** existing labels SHALL remain visible alongside Do Not Spend state
+
+### Requirement: Donate Dust from Do Not Spend-only inputs
+Manage Coins SHALL support a Donate Dust flow using only `Do Not Spend` UTXOs.
+
+#### Scenario: Show Donate Dust CTA when eligible
+- **GIVEN** the wallet has at least one current `Do Not Spend` `UTXO`
+- **WHEN** Manage Coins is rendered
+- **THEN** `Donate Dust` SHALL be available
+
+#### Scenario: Build donation with restricted inputs
+- **GIVEN** user confirms `Donate Dust`
+- **WHEN** donation transaction prerequisites are built
+- **THEN** inputs SHALL include only `Do Not Spend` UTXOs, fee SHALL be paid only from those inputs, and leftover value SHALL target `bc1qyqequr0824nwf7snzvq5gqsr6xscn62e3ttm06`
+
+#### Scenario: Fail when restricted-input tx is impossible
+- **GIVEN** selected `Do Not Spend` UTXOs cannot form a valid transaction at minimum fee rate
+- **WHEN** user confirms `Donate Dust`
+- **THEN** donation SHALL fail with `These coins are too small to donate on their own. Keeper will keep them marked Do Not Spend.` and states SHALL remain unchanged

--- a/openspec/changes/dust-attack-protection-and-donate-dust-v2/specs/wallets/spec.md
+++ b/openspec/changes/dust-attack-protection-and-donate-dust-v2/specs/wallets/spec.md
@@ -1,0 +1,19 @@
+## ADDED Requirements
+
+### Requirement: Wallet-level Do Not Spend indicators
+Wallet listing and wallet details SHALL indicate the presence of current `Do Not Spend` UTXOs.
+
+#### Scenario: Home list red dot
+- **GIVEN** a `Wallet` contains at least one current `UTXO` marked `Do Not Spend`
+- **WHEN** wallet cards are shown on home list
+- **THEN** that wallet card SHALL show the customary red dot indicator
+
+#### Scenario: Wallet details informational line
+- **GIVEN** a wallet contains at least one current `Do Not Spend` `UTXO`
+- **WHEN** wallet details header is rendered
+- **THEN** a non-tappable line SHALL show `Includes Do Not Spend coins`
+
+#### Scenario: More options View All Coins red dot
+- **GIVEN** a wallet contains at least one current `Do Not Spend` `UTXO`
+- **WHEN** More Options is opened
+- **THEN** `View All Coins` SHALL show the customary red dot indicator

--- a/openspec/changes/dust-attack-protection-and-donate-dust-v2/tasks.md
+++ b/openspec/changes/dust-attack-protection-and-donate-dust-v2/tasks.md
@@ -1,0 +1,48 @@
+## 1. Storage (Realm Schema + Migration)
+
+- [x] 1.1 Extend UTXO metadata types and Realm `UTXOInfo` schema with spendability status, reason, and user override fields.
+- [x] 1.2 Bump Realm schema version and add migration logic to initialize new spendability fields for existing records.
+- [x] 1.3 Add helper queries/upserts for reading and writing spendability metadata by `txId:vout` and wallet id.
+- [x] 1.4 Confirm Redux Persist migration version is unchanged (no Redux store shape change) and document this in PR notes.
+
+## 2. Business Logic / Wallet Operations
+
+- [x] 2.1 Implement dust classification helpers (value threshold 5,000 sats, receive reuse/out-of-order, change reuse only).
+- [x] 2.2 Add lightweight address receive metadata update path in wallet sync to avoid full-history rescans.
+- [x] 2.3 Integrate classification into wallet refresh pipeline for new and unclassified current UTXOs while preserving user overrides.
+- [x] 2.4 Implement one-level descendant marking for already-spent potential dust with reason `Linked to potential dust spend`.
+- [x] 2.5 Add one-time dust detection toast marker logic for newly detected potential dust UTXOs.
+
+## 3. Store (Saga + Actions)
+
+- [x] 3.1 Add saga actions for manual `Mark Do Not Spend` and `Mark Spendable` operations and persistence updates.
+- [x] 3.2 Update wallet refresh saga flow to persist classification results and trigger one-time dust toast in normal refresh contexts.
+- [x] 3.3 Add selectors/utilities to compute `hasDoNotSpendUTXO` and spendable-vs-total balances for UI and send flow decisions.
+
+## 4. Transaction Flow and PSBT Safety
+
+- [x] 4.1 Filter automatic input pools in send prerequisite builders to exclude Do Not Spend UTXOs by default.
+- [x] 4.2 Keep explicit manual coin selection path intact with warning confirmation before using Do Not Spend UTXOs.
+- [x] 4.3 Implement Donate Dust transaction preparation using only Do Not Spend UTXOs, minimum fee rate, and donation destination `bc1qyqequr0824nwf7snzvq5gqsr6xscn62e3ttm06`.
+- [x] 4.4 Add failure handling for unbuildable restricted-input Donate Dust transactions with required copy and no state mutation.
+- [x] 4.5 Validate PSBT generation/signing remains unchanged for Wallet, Vault, and Signer flows under filtered input sets.
+
+## 5. UI Components and Screens
+
+- [x] 5.1 Add wallet home red-dot and More Options red-dot indicator wiring based on current Do Not Spend UTXO presence.
+- [x] 5.2 Add Wallet Details informational line `Includes Do Not Spend coins` (non-tappable).
+- [x] 5.3 Update Manage Coins rows to show warning-style `Do Not Spend` label while preserving existing labels (`Change`, `Self`).
+- [x] 5.4 Update UTXO Details to show reason text and actions `Mark Do Not Spend` / `Mark Spendable` with success feedback.
+- [x] 5.5 Add `Donate Dust` CTA + confirmation modal/bottom sheet with exact required copy and cancel path.
+- [x] 5.6 Update send amount flow to show helper text when total balance is sufficient but spendable balance is insufficient.
+- [x] 5.7 Add transaction history/detail informational `Potential dust spend` label and explanation copy.
+- [x] 5.8 Verify UI adheres to DESIGN.md reuse and token guidance (existing components, warning patterns, calm security tone).
+
+## 6. Tests
+
+- [ ] 6.1 Add unit tests for classification rules across receive/change addresses and value boundary conditions (4,999 vs 5,000 sats).
+- [ ] 6.2 Add unit tests for override persistence and one-level descendant marking behavior.
+- [ ] 6.3 Add unit tests for send prerequisite filtering and manual selection warning gating.
+- [ ] 6.4 Add unit/integration tests for Donate Dust success/failure (restricted inputs only, fee-only from Do Not Spend set).
+- [ ] 6.5 Add UI tests for red-dot indicators, Wallet Details info line, Manage Coins labeling, and send helper copy.
+- [ ] 6.6 Add regression checks for hardware signer transaction flows to ensure unchanged PSBT compatibility.

--- a/src/components/UTXOsComponents/UTXOFooter.tsx
+++ b/src/components/UTXOsComponents/UTXOFooter.tsx
@@ -9,7 +9,14 @@ import idx from 'idx';
 import KeeperFooter from '../KeeperFooter';
 import { useColorMode } from '@gluestack-ui/themed-native-base';
 
-function UTXOFooter({ setEnableSelection, enableSelection, wallet, utxos }) {
+function UTXOFooter({
+  setEnableSelection,
+  enableSelection,
+  wallet,
+  utxos,
+  onDonateDust,
+  canDonateDust,
+}) {
   const { translations } = useContext(LocalizationContext);
   const { wallet: walletTranslation } = translations;
   const { colorMode } = useColorMode();
@@ -30,6 +37,13 @@ function UTXOFooter({ setEnableSelection, enableSelection, wallet, utxos }) {
       Icon: colorMode === 'light' ? SendGreen : SendWhite,
       onPress: () => setEnableSelection(!enableSelection),
       disabled: !utxos.length,
+    },
+    {
+      text: 'Donate Dust',
+      Icon: colorMode === 'light' ? SendGreen : SendWhite,
+      onPress: onDonateDust,
+      disabled: !canDonateDust,
+      hideItem: !canDonateDust,
     },
   ];
 

--- a/src/components/UTXOsComponents/UTXOList.tsx
+++ b/src/components/UTXOsComponents/UTXOList.tsx
@@ -1,4 +1,4 @@
-import { FlatList, StyleSheet, TouchableOpacity } from 'react-native';
+import { Alert, FlatList, StyleSheet, TouchableOpacity } from 'react-native';
 import { Box, useColorMode } from '@gluestack-ui/themed-native-base';
 import React, { useContext, useMemo, useState } from 'react';
 import { CommonActions, useNavigation } from '@react-navigation/native';
@@ -15,6 +15,10 @@ import useLabelsNew from 'src/hooks/useLabelsNew';
 import CurrencyInfo from 'src/screens/Home/components/CurrencyInfo';
 import { LocalizationContext } from 'src/context/Localization/LocContext';
 import LabelItem from 'src/screens/UTXOManagement/components/LabelItem';
+import {
+  getUTXOId,
+} from 'src/services/wallets/operations/spendability';
+import { UTXOSpendabilityStatus } from 'src/services/wallets/interfaces';
 
 export function UTXOLabel(props: {
   labels: Array<{ name: string; isSystem: boolean }>;
@@ -111,6 +115,7 @@ function UTXOElement({
   colorMode,
   labels,
   currentWallet,
+  isDoNotSpend,
 }: any) {
   const utxoId = `${item.txId}${item.vout}`;
   const allowSelection = enableSelection;
@@ -119,27 +124,48 @@ function UTXOElement({
   const { labels: txNoteLabels } = useLabelsNew({ txid: item.txId });
   const hasTransactionNote = txNoteLabels && txNoteLabels[item.txId]?.[0]?.name;
 
+  const toggleUTXOSelection = () => {
+    const mapToUpdate = selectedUTXOMap;
+    if (selectedUTXOMap[utxoId]) {
+      delete mapToUpdate[utxoId];
+    } else {
+      mapToUpdate[utxoId] = true;
+    }
+    setSelectedUTXOMap(mapToUpdate);
+    let utxoSum = 0;
+    utxoState.forEach((utxo) => {
+      const eachUTXOId = `${utxo.txId}${utxo.vout}`;
+      if (mapToUpdate[eachUTXOId]) {
+        utxoSum += utxo.value;
+      }
+    });
+    setSelectionTotal(utxoSum);
+  };
+
   return (
     <Box style={styles.utxoElementWrapper} borderBottomColor={`${colorMode}.separator`}>
       <TouchableOpacity
         style={styles.utxoCardContainer}
         onPress={() => {
           if (allowSelection) {
-            const mapToUpdate = selectedUTXOMap;
-            if (selectedUTXOMap[utxoId]) {
-              delete mapToUpdate[utxoId];
-            } else {
-              mapToUpdate[utxoId] = true;
+            if (isDoNotSpend && !selectedUTXOMap[utxoId]) {
+              Alert.alert(
+                'Use Do Not Spend Coin?',
+                'This coin was marked Do Not Spend to help protect wallet privacy. Spending it with other coins may reduce privacy.',
+                [
+                  {
+                    text: 'Cancel',
+                    style: 'cancel',
+                  },
+                  {
+                    text: 'Use Coin',
+                    onPress: toggleUTXOSelection,
+                  },
+                ]
+              );
+              return;
             }
-            setSelectedUTXOMap(mapToUpdate);
-            let utxoSum = 0;
-            utxoState.forEach((utxo) => {
-              const utxoId = `${utxo.txId}${utxo.vout}`;
-              if (mapToUpdate[utxoId]) {
-                utxoSum += utxo.value;
-              }
-            });
-            setSelectionTotal(utxoSum);
+            toggleUTXOSelection();
           } else {
             navigation.dispatch(
               CommonActions.navigate('UTXOLabeling', { utxo: item, wallet: currentWallet })
@@ -248,6 +274,14 @@ function UTXOList({
   const { translations } = useContext(LocalizationContext);
   const { wallet: walletTranslation } = translations;
   const { labels } = useLabelsNew({ utxos: utxoState });
+  const utxoSpendability = useAppSelector((state) => state.utxos.spendability);
+  const spendabilityMap = useMemo(
+    () =>
+      currentWallet
+        ? new Map(Object.entries(utxoSpendability[currentWallet.id] || {}))
+        : new Map(),
+    [utxoSpendability, currentWallet?.id]
+  );
   const dispatch = useDispatch();
   const { walletSyncing } = useAppSelector((state) => state.wallet);
   const syncing = walletSyncing && currentWallet ? !!walletSyncing[currentWallet.id] : false;
@@ -271,8 +305,21 @@ function UTXOList({
       refreshing={!!syncing}
       onRefresh={pullDownRefresh}
       renderItem={({ item }) => (
+        (() => {
+          const baseLabels = labels ? labels[`${item.txId}:${item.vout}`] || [] : [];
+          const utxoSpendability = spendabilityMap.get(getUTXOId(item));
+          const hasDoNotSpendLabel = baseLabels.some((label) => label.name === 'Do Not Spend');
+          const rowLabels =
+            utxoSpendability?.spendabilityStatus === UTXOSpendabilityStatus.DO_NOT_SPEND &&
+            !hasDoNotSpendLabel
+              ? [{ name: 'Do Not Spend', isSystem: true }, ...baseLabels]
+              : baseLabels;
+          const isDoNotSpend =
+            utxoSpendability?.spendabilityStatus === UTXOSpendabilityStatus.DO_NOT_SPEND;
+
+          return (
         <UTXOElement
-          labels={labels ? labels[`${item.txId}:${item.vout}`] || [] : []}
+          labels={rowLabels}
           item={item}
           enableSelection={enableSelection}
           selectedUTXOMap={selectedUTXOMap}
@@ -282,7 +329,10 @@ function UTXOList({
           navigation={navigation}
           colorMode={colorMode}
           currentWallet={currentWallet}
+          isDoNotSpend={isDoNotSpend}
         />
+          );
+        })()
       )}
       keyExtractor={(item: UTXO) => `${item.txId}${item.vout}${item.confirmed}`}
       showsVerticalScrollIndicator={false}

--- a/src/hardware/coldcard/index.ts
+++ b/src/hardware/coldcard/index.ts
@@ -4,14 +4,13 @@ import NFC from 'src/services/nfc';
 import { NfcTech } from 'react-native-nfc-manager';
 import { HWErrorType } from 'src/models/enums/Hardware';
 import { XpubTypes } from 'src/services/wallets/enums';
-import { getWalletConfig } from '..';
 import HWError from '../HWErrorState';
 
-export const registerToColcard = async ({ vault }: { vault: Vault }) => {
-  const config = getWalletConfig({ vault });
-  const enc = NFC.encodeTextRecord(config);
-  await NFC.send(NfcTech.Ndef, enc);
-};
+// export const registerToColcard = async ({ vault }: { vault: Vault }) => {
+//   const config = getWalletConfig({ vault }); // add support for miniscript vaults before using this function
+//   const enc = NFC.encodeTextRecord(config);
+//   await NFC.send(NfcTech.Ndef, enc);
+// };
 
 export const extractColdCardExport = (data, isMultisig) => {
   const xpubDetails: XpubDetailsType = {};

--- a/src/screens/Home/components/Wallet/HomeWallet.tsx
+++ b/src/screens/Home/components/Wallet/HomeWallet.tsx
@@ -43,6 +43,7 @@ import {
 import useToastMessage from 'src/hooks/useToastMessage';
 import TickIcon from 'src/assets/images/icon_tick.svg';
 import ToastErrorIcon from 'src/assets/images/toast_error.svg';
+import { hasDoNotSpendUTXOs } from 'src/services/wallets/operations/spendability';
 
 const HomeWallet = () => {
   const { colorMode } = useColorMode();
@@ -60,6 +61,7 @@ const HomeWallet = () => {
   const { usdtWallets, createWallet } = useUSDTWallets();
   const { collaborativeSession } = useAppSelector((state) => state.vault);
   const { bitcoinNetworkType } = useAppSelector((state) => state.settings);
+  const utxoSpendability = useAppSelector((state) => state.utxos.spendability);
 
   const dispatch = useDispatch();
   const [showAddWalletModal, setShowAddWalletModal] = useState(false);
@@ -208,6 +210,13 @@ const HomeWallet = () => {
         navigation.navigate('WalletDetails', { walletId: item.id, autoRefresh: true });
       }
     };
+    const showDoNotSpendDot =
+      item.entityKind !== EntityKind.USDT_WALLET &&
+      hasDoNotSpendUTXOs(
+        new Map(Object.entries(utxoSpendability[item.id] || {})),
+        [...item.specs.confirmedUTXOs, ...item.specs.unconfirmedUTXOs]
+      );
+
     return (
       <TouchableOpacity
         onPress={() => handleWalletPress(item, navigation)}
@@ -231,6 +240,7 @@ const HomeWallet = () => {
           wallet={item}
           isShowAmount={isShowAmount}
           setIsShowAmount={setIsShowAmount}
+          showAlertDot={showDoNotSpendDot}
         />
       </TouchableOpacity>
     );

--- a/src/screens/Home/components/Wallet/WalletCard.tsx
+++ b/src/screens/Home/components/Wallet/WalletCard.tsx
@@ -26,6 +26,7 @@ type WalletCardProps = {
   allowHideBalance?: boolean;
   isShowAmount?: boolean;
   setIsShowAmount?: () => void;
+  showAlertDot?: boolean;
 };
 
 const WalletCard: React.FC<WalletCardProps> = ({
@@ -41,6 +42,7 @@ const WalletCard: React.FC<WalletCardProps> = ({
   allowHideBalance = true,
   isShowAmount,
   setIsShowAmount,
+  showAlertDot = false,
 }) => {
   const defaultHexagonBackgroundColor = Colors.headerWhite;
   const { getWalletIcon } = useWalletAsset();
@@ -68,6 +70,7 @@ const WalletCard: React.FC<WalletCardProps> = ({
           <CardPill key={tag} heading={tag} backgroundColor={color} />
         ))}
       </Box>
+      {showAlertDot ? <Box style={styles.redDot} /> : null}
 
       <Box style={styles.bottomContainer}>
         <Box style={styles.bottomLeft}>
@@ -153,6 +156,15 @@ const styles = StyleSheet.create({
   },
   secondCard: {
     maxWidth: wp(80),
+  },
+  redDot: {
+    width: 10,
+    height: 10,
+    borderRadius: 10,
+    position: 'absolute',
+    right: wp(14),
+    top: hp(14),
+    backgroundColor: Colors.red,
   },
   usdtContainer: {},
 });

--- a/src/screens/Send/AddSendAmount.tsx
+++ b/src/screens/Send/AddSendAmount.tsx
@@ -1,7 +1,7 @@
 import Text from 'src/components/KeeperText';
 import { Box, useColorMode } from '@gluestack-ui/themed-native-base';
 import { StyleSheet, TouchableOpacity } from 'react-native';
-import React, { useContext, useEffect, useState } from 'react';
+import React, { useContext, useEffect, useMemo, useState } from 'react';
 import {
   calculateCustomFee,
   calculateSendMaxFee,
@@ -50,6 +50,7 @@ import CurrencyInfo from '../Home/components/CurrencyInfo';
 import CustomPriorityModal from './CustomPriorityModal';
 import PriorityModal from './PriorityModal';
 import WalletHeader from 'src/components/WalletHeader';
+import { getSpendableBalance, getTotalBalance } from 'src/services/wallets/operations/spendability';
 
 const capitalizeFirstLetter = (string) => {
   if (!string) return '';
@@ -84,6 +85,8 @@ function AddSendAmount({ route }) {
     totalRecipients = 1,
     currentRecipientIdx = 1,
     miniscriptSelectedSatisfier = null,
+    donateDustMode = false,
+    donateDustFeePerByte = 1,
   }: {
     sender: Wallet | Vault;
     internalRecipients: (Wallet | Vault)[];
@@ -102,6 +105,8 @@ function AddSendAmount({ route }) {
     totalRecipients: number;
     currentRecipientIdx: number;
     miniscriptSelectedSatisfier?: MiniscriptTxSelectedSatisfier;
+    donateDustMode?: boolean;
+    donateDustFeePerByte?: number;
   } = route.params;
   const [amount, setAmount] = useState(prefillAmount || '0');
   const [amountToSend, setAmountToSend] = useState('0');
@@ -112,6 +117,7 @@ function AddSendAmount({ route }) {
   const sendMaxFee = useAppSelector((state) => state.sendAndReceive.sendMaxFee);
   const sendPhaseOneState = useAppSelector((state) => state.sendAndReceive.sendPhaseOne);
   const { averageTxFees } = useAppSelector((state) => state.network);
+  const utxoSpendability = useAppSelector((state) => state.utxos.spendability);
 
   const exchangeRates = useExchangeRates();
   const currencyCode = useCurrencyCode();
@@ -122,7 +128,14 @@ function AddSendAmount({ route }) {
     parentScreen === MANAGEWALLETS ||
     parentScreen === VAULTSETTINGS ||
     parentScreen === WALLETSETTINGS;
-  const availableBalance = sender.specs.balances.confirmed + sender.specs.balances.unconfirmed;
+  const allWalletUTXOs = [...sender.specs.confirmedUTXOs, ...sender.specs.unconfirmedUTXOs];
+  const totalWalletBalance = getTotalBalance(allWalletUTXOs);
+  const spendabilityMap = useMemo(
+    () => new Map(Object.entries(utxoSpendability[sender.id] || {})),
+    [utxoSpendability, sender.id]
+  );
+  const spendableWalletBalance = getSpendableBalance(spendabilityMap, allWalletUTXOs);
+  const availableBalance = spendableWalletBalance;
 
   const isDarkMode = colorMode === 'dark';
   const [localCurrencyKind, setLocalCurrencyKind] = useState(currentCurrency);
@@ -130,12 +143,15 @@ function AddSendAmount({ route }) {
   const [isSendingMax, setIsSendingMax] = useState(isSendMax);
   const [transPriorityModalVisible, setTransPriorityModalVisible] = useState(false);
   const [visibleCustomPriorityModal, setVisibleCustomPriorityModal] = useState(false);
-  const [transactionPriority, setTransactionPriority] = useState(TxPriority.LOW);
-  const [customFeePerByte, setCustomFeePerByte] = useState(0);
+  const [transactionPriority, setTransactionPriority] = useState(
+    donateDustMode ? TxPriority.CUSTOM : TxPriority.LOW
+  );
+  const [customFeePerByte, setCustomFeePerByte] = useState(
+    donateDustMode ? donateDustFeePerByte : 0
+  );
   const [customEstBlocks, setCustomEstBlocks] = useState(0);
   const [estimationSign, setEstimationSign] = useState('≈');
-  const balance = idx(sender, (_) => _.specs.balances);
-  let availableToSpend = balance.confirmed + balance.unconfirmed;
+  let availableToSpend = spendableWalletBalance;
 
   const haveSelectedUTXOs = selectedUTXOs && selectedUTXOs.length;
   if (haveSelectedUTXOs) availableToSpend = selectedUTXOs.reduce((a, c) => a + c.value, 0);
@@ -144,6 +160,11 @@ function AddSendAmount({ route }) {
     const totalSpent = finalRecipients.reduce((sum, recipient) => sum + recipient.amount, 0);
     availableToSpend -= totalSpent;
   }
+
+  const showDoNotSpendBalanceHelper =
+    !haveSelectedUTXOs &&
+    Number(amountToSend) > availableToSpend &&
+    Number(amountToSend) <= totalWalletBalance;
 
   function convertFiatToSats(fiatAmount: number) {
     return exchangeRates && exchangeRates[currencyCode]
@@ -280,6 +301,14 @@ function AddSendAmount({ route }) {
   }, [isMoveAllFunds, sendMaxFee, selectedUTXOs, transactionPriority, customFeePerByte]);
 
   useEffect(() => {
+    if (!donateDustMode) return;
+    const lowEstimatedBlocks = averageTxFees?.[bitcoinNetworkType]?.[TxPriority.LOW]?.estimatedBlocks;
+    if (lowEstimatedBlocks) {
+      setCustomEstBlocks(lowEstimatedBlocks);
+    }
+  }, [donateDustMode, averageTxFees, bitcoinNetworkType]);
+
+  useEffect(() => {
     if (!currentAmount) {
       setAmountToSend('');
       return;
@@ -340,6 +369,7 @@ function AddSendAmount({ route }) {
           customEstimatedBlocks: customEstBlocks.toString(),
           selectedUTXOs,
           miniscriptSelectedSatisfier,
+          donateDustMode,
         })
       );
     }
@@ -356,6 +386,7 @@ function AddSendAmount({ route }) {
         transactionPriority,
         customFeePerByte,
         miniscriptSelectedSatisfier,
+        donateDustMode,
       })
     );
   };
@@ -389,6 +420,12 @@ function AddSendAmount({ route }) {
       showToast(errorText.enterValidAmount);
       return;
     }
+
+    if (donateDustMode) {
+      navigateToNext();
+      return;
+    }
+
     const amountInSats = isSendingMax
       ? satsEnabled
         ? maxAmountToSend
@@ -584,11 +621,19 @@ function AddSendAmount({ route }) {
         currencyCode={currencyCode}
         specificBitcoinAmount={maxAmountToSend}
       />
+      {showDoNotSpendBalanceHelper ? (
+        <Text fontSize={12} color={`${colorMode}.textBlack`} style={{ marginTop: hp(8) }}>
+          Some coins are marked Do Not Spend and are not available for this payment.
+        </Text>
+      ) : null}
 
       {currentRecipientIdx === totalRecipients ? (
         <TouchableOpacity
-          onPress={() => setTransPriorityModalVisible(true)}
+          onPress={() => {
+            if (!donateDustMode) setTransPriorityModalVisible(true);
+          }}
           testID="transaction_priority"
+          disabled={donateDustMode}
         >
           <Box
             style={[styles.dashedButton]}

--- a/src/screens/Send/SendConfirmation.tsx
+++ b/src/screens/Send/SendConfirmation.tsx
@@ -67,6 +67,7 @@ import WalletIcon from 'src/assets/images/daily_wallet.svg';
 import MultiSendSvg from 'src/assets/images/@.svg';
 import useExchangeRates from 'src/hooks/useExchangeRates';
 import Relay from 'src/services/backend/Relay';
+import { DONATE_DUST_UNBUILDABLE_ERROR } from 'src/services/wallets/operations/spendability';
 
 export interface SendConfirmationRouteParams {
   sender: Wallet | Vault;
@@ -82,6 +83,7 @@ export interface SendConfirmationRouteParams {
   customFeePerByte: number;
   miniscriptSelectedSatisfier?: MiniscriptTxSelectedSatisfier;
   tipMessage: string;
+  donateDustMode?: boolean;
 }
 
 export interface tnxDetailsProps {
@@ -113,6 +115,7 @@ function SendConfirmation({ route }) {
     customFeePerByte: initialCustomFeePerByte,
     miniscriptSelectedSatisfier,
     tipMessage = '',
+    donateDustMode = false,
   }: SendConfirmationRouteParams = route.params;
   const navigation = useNavigation();
   const exchangeRates = useExchangeRates();
@@ -125,6 +128,12 @@ function SendConfirmation({ route }) {
   );
   const customTxRecipientsOptions = useAppSelector(
     (state) => state.sendAndReceive.customPrioritySendPhaseOne?.outputs?.customTxRecipients
+  );
+  const customPriorityHasFailed = useAppSelector(
+    (state) => state.sendAndReceive.customPrioritySendPhaseOne?.hasFailed
+  );
+  const customPriorityFailureMessage = useAppSelector(
+    (state) => state.sendAndReceive.customPrioritySendPhaseOne?.failedErrorMessage
   );
   const sendMaxFee = useAppSelector((state) => state.sendAndReceive.sendMaxFee);
 
@@ -546,6 +555,14 @@ function SendConfirmation({ route }) {
     }
   }, [sendPhaseTwoFailed]);
 
+  useEffect(() => {
+    if (!donateDustMode) return;
+    if (!customPriorityHasFailed) return;
+
+    showToast(customPriorityFailureMessage || DONATE_DUST_UNBUILDABLE_ERROR, <ToastErrorIcon />);
+    navigation.goBack();
+  }, [donateDustMode, customPriorityHasFailed, customPriorityFailureMessage]);
+
   const createZendeskTipTicket = async () => {
     await Relay.createZendeskTicket({
       desc: tipMessage.trim(),
@@ -682,10 +699,10 @@ function SendConfirmation({ route }) {
             <TouchableOpacity
               testID="btn_transactionPriority"
               onPress={() => setTransPriorityModalVisible(true)}
-              disabled={isCachedTransaction} // disable change priority for AutoTransfers
+              disabled={isCachedTransaction || donateDustMode} // disable change priority for AutoTransfers and Donate Dust
             >
               <TransactionPriorityDetails
-                disabled={isCachedTransaction}
+                disabled={isCachedTransaction || donateDustMode}
                 transactionPriority={transactionPriority}
                 txFeeInfo={txFeeInfo}
                 getBalance={getBalance}
@@ -817,35 +834,37 @@ function SendConfirmation({ route }) {
         )}
       />
       {/* Transaction Priority Modal */}
-      <KeeperModal
-        visible={transPriorityModalVisible}
-        close={() => setTransPriorityModalVisible(false)}
-        title={walletTranslations.transactionPriority}
-        subTitle={walletTranslations.transactionPrioritySubTitle}
-        buttonText={common.confirm}
-        buttonCallback={() => {
-          setTransPriorityModalVisible(false), setTransactionPriority;
-        }}
-        secondaryButtonText={common.cancel}
-        secondaryCallback={() => setTransPriorityModalVisible(false)}
-        Content={() => (
-          <PriorityModal
-            selectedPriority={transactionPriority}
-            setSelectedPriority={setTransactionPriority}
-            averageTxFees={averageTxFees[bitcoinNetworkType]}
-            txFeeInfo={txFeeInfo}
-            customFeePerByte={customFeePerByte}
-            onOpenCustomPriorityModal={() => {
-              dispatch(customPrioritySendPhaseOneStatusReset());
-              setVisibleCustomPriorityModal(true);
-            }}
-            customEstBlocks={customEstBlocks}
-            setCustomEstBlocks={setCustomEstBlocks}
-            estimationSign={estimationSign}
-            setEstimationSign={setEstimationSign}
-          />
-        )}
-      />
+      {!donateDustMode ? (
+        <KeeperModal
+          visible={transPriorityModalVisible}
+          close={() => setTransPriorityModalVisible(false)}
+          title={walletTranslations.transactionPriority}
+          subTitle={walletTranslations.transactionPrioritySubTitle}
+          buttonText={common.confirm}
+          buttonCallback={() => {
+            setTransPriorityModalVisible(false), setTransactionPriority;
+          }}
+          secondaryButtonText={common.cancel}
+          secondaryCallback={() => setTransPriorityModalVisible(false)}
+          Content={() => (
+            <PriorityModal
+              selectedPriority={transactionPriority}
+              setSelectedPriority={setTransactionPriority}
+              averageTxFees={averageTxFees[bitcoinNetworkType]}
+              txFeeInfo={txFeeInfo}
+              customFeePerByte={customFeePerByte}
+              onOpenCustomPriorityModal={() => {
+                dispatch(customPrioritySendPhaseOneStatusReset());
+                setVisibleCustomPriorityModal(true);
+              }}
+              customEstBlocks={customEstBlocks}
+              setCustomEstBlocks={setCustomEstBlocks}
+              estimationSign={estimationSign}
+              setEstimationSign={setEstimationSign}
+            />
+          )}
+        />
+      ) : null}
       {/* High fee alert Modal */}
       <KeeperModal
         visible={highFeeAlertVisible}
@@ -955,7 +974,7 @@ function SendConfirmation({ route }) {
         subTitleColor={`${colorMode}.modalSubtitleBlack`}
         Content={otpContent}
       />
-      {visibleCustomPriorityModal && (
+      {!donateDustMode && visibleCustomPriorityModal && (
         <CustomPriorityModal
           visible={visibleCustomPriorityModal}
           close={() => setVisibleCustomPriorityModal(false)}

--- a/src/screens/UTXOManagement/UTXOLabeling.tsx
+++ b/src/screens/UTXOManagement/UTXOLabeling.tsx
@@ -8,6 +8,7 @@ import { UTXO } from 'src/services/wallets/interfaces';
 import { LabelRefType, NetworkType } from 'src/services/wallets/enums';
 import { useDispatch } from 'react-redux';
 import { addLabels, bulkUpdateLabels } from 'src/store/sagaActions/utxos';
+import { markDoNotSpendUTXO, markSpendableUTXO } from 'src/store/sagaActions/utxos';
 import TickIcon from 'src/assets/images/icon_tick.svg';
 import BtcBlack from 'src/assets/images/btc_black.svg';
 import BtcWhite from 'src/assets/images/btc_white.svg';
@@ -28,6 +29,14 @@ import { EditNoteContent } from '../ViewTransactions/TransactionDetails';
 import KeeperModal from 'src/components/KeeperModal';
 import LabelsEditor, { getLabelChanges } from './components/LabelsEditor';
 import WalletHeader from 'src/components/WalletHeader';
+import Buttons from 'src/components/Buttons';
+import {
+  getUTXOId,
+} from 'src/services/wallets/operations/spendability';
+import {
+  UTXOSpendabilityReason,
+  UTXOSpendabilityStatus,
+} from 'src/services/wallets/interfaces';
 
 function UTXOLabeling() {
   const { showToast } = useToastMessage();
@@ -50,6 +59,15 @@ function UTXOLabeling() {
   const { transactions: txTranslations, wallet: walletTranslations, common } = translations;
 
   const dispatch = useDispatch();
+  const utxoSpendability = useAppSelector((state) => state.utxos.spendability);
+  const spendabilityMap = new Map(Object.entries(utxoSpendability[wallet.id] || {}));
+  const utxoSpendabilityInfo = spendabilityMap.get(getUTXOId(utxo));
+  const [spendabilityStatus, setSpendabilityStatus] = useState<UTXOSpendabilityStatus>(
+    utxoSpendabilityInfo?.spendabilityStatus || UTXOSpendabilityStatus.SPENDABLE
+  );
+  const [spendabilityReason, setSpendabilityReason] = useState<UTXOSpendabilityReason | undefined>(
+    utxoSpendabilityInfo?.spendabilityReason
+  );
 
   function InfoCard({
     title,
@@ -140,6 +158,17 @@ function UTXOLabeling() {
     );
   };
 
+  const getSpendabilityReasonText = () => {
+    if (spendabilityReason === UTXOSpendabilityReason.POTENTIAL_DUST_PAYMENT)
+      return 'Potential dust payment';
+    if (spendabilityReason === UTXOSpendabilityReason.LINKED_TO_POTENTIAL_DUST_SPEND)
+      return 'Linked to potential dust spend';
+    if (spendabilityReason === UTXOSpendabilityReason.MARKED_MANUALLY) return 'Marked manually';
+    return '';
+  };
+
+  const isDoNotSpend = spendabilityStatus === UTXOSpendabilityStatus.DO_NOT_SPEND;
+
   return (
     <ScreenWrapper backgroundcolor={`${colorMode}.primaryBackground`}>
       <WalletHeader
@@ -212,9 +241,42 @@ function UTXOLabeling() {
               Icon={colorMode === 'light' ? <Link /> : <LinkWhite />}
               onIconPress={() => redirectToBlockExplorer('tx')}
             />
+            {isDoNotSpend ? (
+              <>
+                <InfoCard title={'Do Not Spend'} description={getSpendabilityReasonText()} />
+                {spendabilityReason !== UTXOSpendabilityReason.MARKED_MANUALLY ? (
+                  <InfoCard
+                    title={'Reason'}
+                    description={
+                      'Keeper marked this coin Do Not Spend to help protect wallet privacy.'
+                    }
+                    numberOfLines={3}
+                  />
+                ) : null}
+              </>
+            ) : null}
           </Box>
         </Box>
       </ScrollView>
+      <Box style={styles.ctaBtnWrapper}>
+        <Buttons
+          primaryText={isDoNotSpend ? 'Mark Spendable' : 'Mark Do Not Spend'}
+          fullWidth
+          primaryCallback={() => {
+            if (isDoNotSpend) {
+              dispatch(markSpendableUTXO({ walletId: wallet.id, utxo }));
+              setSpendabilityStatus(UTXOSpendabilityStatus.SPENDABLE);
+              setSpendabilityReason(undefined);
+              showToast('Coin marked spendable', <TickIcon />);
+            } else {
+              dispatch(markDoNotSpendUTXO({ walletId: wallet.id, utxo }));
+              setSpendabilityStatus(UTXOSpendabilityStatus.DO_NOT_SPEND);
+              setSpendabilityReason(UTXOSpendabilityReason.MARKED_MANUALLY);
+              showToast('Coin marked Do Not Spend', <TickIcon />);
+            }
+          }}
+        />
+      </Box>
       <KeeperModal
         visible={txNoteModalVisible}
         modalBackground={`${colorMode}.modalWhiteBackground`}

--- a/src/screens/UTXOManagement/UTXOManagement.tsx
+++ b/src/screens/UTXOManagement/UTXOManagement.tsx
@@ -10,8 +10,8 @@ import { StyleSheet } from 'react-native';
 import UTXOSelectionTotal from 'src/components/UTXOsComponents/UTXOSelectionTotal';
 import { Wallet } from 'src/services/wallets/interfaces/wallet';
 import { Vault } from 'src/services/wallets/interfaces/vault';
-import { EntityKind, VaultType } from 'src/services/wallets/enums';
-import { CommonActions, useNavigation } from '@react-navigation/native';
+import { EntityKind, TxPriority, VaultType } from 'src/services/wallets/enums';
+import { CommonActions, StackActions, useNavigation } from '@react-navigation/native';
 import useWallets from 'src/hooks/useWallets';
 import { Box, useColorMode } from '@gluestack-ui/themed-native-base';
 import { refreshWallets } from 'src/store/sagaActions/wallets';
@@ -28,8 +28,25 @@ import WalletHeader from 'src/components/WalletHeader';
 import CurrencyTypeSwitch from 'src/components/Switch/CurrencyTypeSwitch';
 import ThemedSvg from 'src/components/ThemedSvg.tsx/ThemedSvg';
 import { LocalizationContext } from 'src/context/Localization/LocContext';
+import KeeperModal from 'src/components/KeeperModal';
+import {
+  DONATE_DUST_DESTINATION,
+  DONATE_DUST_UNBUILDABLE_ERROR,
+  getDoNotSpendUTXOs,
+  MIN_DONATE_DUST_FEE_RATE,
+} from 'src/services/wallets/operations/spendability';
+import WalletOperations from 'src/services/wallets/operations';
+import { MANAGEWALLETS } from 'src/navigation/contants';
 
-function Footer({ utxos, wallet, setEnableSelection, enableSelection, selectedUTXOs }) {
+function Footer({
+  utxos,
+  wallet,
+  setEnableSelection,
+  enableSelection,
+  selectedUTXOs,
+  canDonateDust,
+  onDonateDust,
+}) {
   const navigation = useNavigation();
   const { showToast } = useToastMessage();
   const miniscriptPathSelectorRef = useRef<MiniscriptPathSelectorRef>(null);
@@ -77,12 +94,16 @@ function Footer({ utxos, wallet, setEnableSelection, enableSelection, selectedUT
       enableSelection={enableSelection}
       wallet={wallet}
       utxos={utxos}
+      onDonateDust={onDonateDust}
+      canDonateDust={canDonateDust}
     />
   );
 }
 type ScreenProps = NativeStackScreenProps<AppStackParams, 'UTXOManagement'>;
 function UTXOManagement({ route }: ScreenProps) {
   const { colorMode } = useColorMode();
+  const navigation = useNavigation();
+  const { showToast } = useToastMessage();
   const dispatch = useAppDispatch();
   const { data, routeName, vaultId = '' } = route.params || {};
   const [enableSelection, _setEnableSelection] = useState(false);
@@ -94,6 +115,7 @@ function UTXOManagement({ route }: ScreenProps) {
     : useWallets({ walletIds: [id] }).wallets[0];
   const [selectedWallet, setSelectedWallet] = useState<Wallet | Vault>(wallet);
   const [selectedUTXOs, setSelectedUTXOs] = useState([]);
+  const [showDonateDustModal, setShowDonateDustModal] = useState(false);
   const { walletSyncing } = useAppSelector((state) => state.wallet);
   const syncing = walletSyncing && selectedWallet ? !!walletSyncing[selectedWallet.id] : false;
   const { translations } = useContext(LocalizationContext);
@@ -125,6 +147,55 @@ function UTXOManagement({ route }: ScreenProps) {
           })
         )
     : [];
+  const utxoSpendability = useAppSelector((state) => state.utxos.spendability);
+  const spendabilityMap = selectedWallet
+    ? new Map(Object.entries(utxoSpendability[selectedWallet.id] || {}))
+    : new Map();
+  const doNotSpendUTXOs = selectedWallet ? getDoNotSpendUTXOs(spendabilityMap, utxos) : [];
+
+  const handleConfirmDonateDust = useCallback(() => {
+    if (!selectedWallet || !doNotSpendUTXOs.length) {
+      setShowDonateDustModal(false);
+      return;
+    }
+
+    const totalDoNotSpendSats = doNotSpendUTXOs.reduce((sum, utxo) => sum + utxo.value, 0);
+    const donationOutput = [{ address: DONATE_DUST_DESTINATION, value: totalDoNotSpendSats }];
+
+    const { txPrerequisites } = WalletOperations.prepareCustomTransactionPrerequisites(
+      selectedWallet,
+      donationOutput,
+      MIN_DONATE_DUST_FEE_RATE,
+      doNotSpendUTXOs
+    );
+
+    const donationInputs = txPrerequisites?.[TxPriority.CUSTOM]?.inputs;
+    if (!donationInputs || !donationInputs.length) {
+      setShowDonateDustModal(false);
+      showToast(DONATE_DUST_UNBUILDABLE_ERROR);
+      return;
+    }
+
+    setShowDonateDustModal(false);
+    navigation.dispatch(
+      StackActions.push('AddSendAmount', {
+        sender: selectedWallet,
+        internalRecipients: [null],
+        address: DONATE_DUST_DESTINATION,
+        amount: '0',
+        note: 'Donate Dust',
+        selectedUTXOs: doNotSpendUTXOs,
+        totalUtxosAmount: totalDoNotSpendSats,
+        parentScreen: MANAGEWALLETS,
+        isSendMax: true,
+        recipients: [],
+        totalRecipients: 1,
+        currentRecipientIdx: 1,
+        donateDustMode: true,
+        donateDustFeePerByte: MIN_DONATE_DUST_FEE_RATE,
+      })
+    );
+  }, [selectedWallet, doNotSpendUTXOs, navigation, showToast]);
 
   useEffect(() => {
     const selectedUtxos = utxos || [];
@@ -178,10 +249,37 @@ function UTXOManagement({ route }: ScreenProps) {
               setEnableSelection={setEnableSelection}
               enableSelection={enableSelection}
               selectedUTXOs={selectedUTXOs}
+              canDonateDust={doNotSpendUTXOs.length > 0}
+              onDonateDust={() => setShowDonateDustModal(true)}
             />
           ) : null}
         </Box>
       </Box>
+      <KeeperModal
+        visible={showDonateDustModal}
+        close={() => setShowDonateDustModal(false)}
+        title="Donate Dust"
+        subTitle="Only coins marked Do Not Spend will be used. Fees are paid from those coins only."
+        buttonText="Donate Dust"
+        buttonCallback={handleConfirmDonateDust}
+        secondaryButtonText={common.cancel}
+        secondaryCallback={() => setShowDonateDustModal(false)}
+        Content={() => (
+          <Box>
+            <Box marginTop={hp(5)}>
+              <Box marginBottom={hp(8)}>
+                <ThemedSvg name={'NoTransactionIcon'} />
+              </Box>
+              <Box marginBottom={hp(6)}>
+                <UTXOSelectionTotal
+                  selectionTotal={doNotSpendUTXOs.reduce((sum, utxo) => sum + utxo.value, 0)}
+                  selectedUTXOs={doNotSpendUTXOs}
+                />
+              </Box>
+            </Box>
+          </Box>
+        )}
+      />
     </ScreenWrapper>
   );
 }

--- a/src/screens/UTXOManagement/components/LabelItem.tsx
+++ b/src/screens/UTXOManagement/components/LabelItem.tsx
@@ -5,6 +5,9 @@ import DeleteCross from 'src/assets/images/deletelabel.svg';
 import Text from 'src/components/KeeperText';
 import { sha256 } from 'bitcoinjs-lib/src/crypto';
 import { hp, wp } from 'src/constants/responsive';
+import Colors from 'src/theme/Colors';
+
+const DO_NOT_SPEND_LABEL = 'Do Not Spend';
 
 function LabelItem({
   item,
@@ -52,7 +55,7 @@ function LabelItem({
           onLayout(event, index);
         }
       }}
-      backgroundColor={getLabelColor(item.name)}
+      backgroundColor={item.name === DO_NOT_SPEND_LABEL ? Colors.red : getLabelColor(item.name)}
     >
       <TouchableOpacity
         style={styles.labelEditContainer}

--- a/src/screens/ViewTransactions/TransactionDetails.tsx
+++ b/src/screens/ViewTransactions/TransactionDetails.tsx
@@ -67,6 +67,9 @@ function TransactionDetails({ route }) {
   const { transactions, common } = translations;
   const { transaction, wallet }: { transaction: Transaction; wallet: Wallet } = route.params;
   const { labels } = useLabelsNew({ txid: transaction.txid });
+  const hasPotentialDustSpendLabel = (labels[transaction.txid] || []).some(
+    (label) => label.name === 'Potential dust spend'
+  );
   const [visible, setVisible] = React.useState(false);
   const close = () => setVisible(false);
   const noteRef = useRef();
@@ -261,6 +264,16 @@ function TransactionDetails({ route }) {
                 showIcon={false}
                 letterSpacing={2.4}
               />
+              {hasPotentialDustSpendLabel ? (
+                <InfoCard
+                  title={'Potential dust spend'}
+                  describtion={
+                    'This transaction may have spent a suspicious small amount together with other wallet funds. This may have reduced wallet privacy.'
+                  }
+                  showIcon={false}
+                  numberOfLines={3}
+                />
+              ) : null}
             </Box>
             <Pressable
               onPress={() => {

--- a/src/screens/WalletDetails/WalletDetails.tsx
+++ b/src/screens/WalletDetails/WalletDetails.tsx
@@ -24,6 +24,7 @@ import { sendPhaseOneReset } from 'src/store/reducers/send_and_receive';
 import WalletDetailHeader from './components/WalletDetailHeader';
 import DetailCards from './components/DetailCards';
 import ThemedColor from 'src/components/ThemedColor/ThemedColor';
+import { hasDoNotSpendUTXOs } from 'src/services/wallets/operations/spendability';
 
 // TODO: add type definitions to all components
 function TransactionsAndUTXOs({ transactions, setPullRefresh, pullRefresh, wallet }) {
@@ -69,6 +70,16 @@ function WalletDetails({ route }: ScreenProps) {
   const introModal = useAppSelector((state) => state.wallet.introModal) || false;
   const [pullRefresh, setPullRefresh] = useState(false);
   const viewAll_color = ThemedColor({ name: 'viewAll_color' });
+  const utxoSpendability = useAppSelector((state) => state.utxos.spendability);
+  const spendabilityMap = wallet
+    ? new Map(Object.entries(utxoSpendability[wallet.id] || {}))
+    : new Map();
+  const showDoNotSpendInfo =
+    !!wallet &&
+    hasDoNotSpendUTXOs(spendabilityMap, [
+      ...wallet.specs.confirmedUTXOs,
+      ...wallet.specs.unconfirmedUTXOs,
+    ]);
 
   useEffect(() => {
     dispatch(sendPhaseOneReset());
@@ -128,6 +139,7 @@ function WalletDetails({ route }: ScreenProps) {
         totalBalance={wallet.specs.balances.confirmed + wallet.specs.balances.unconfirmed}
         description={wallet.presentationData.description}
         wallet={wallet}
+        showDoNotSpendInfo={showDoNotSpendInfo}
       />
       <Box style={styles.detailCardsContainer}>
         <Box style={styles.detailCards}>

--- a/src/screens/WalletDetails/components/DetailCards.tsx
+++ b/src/screens/WalletDetails/components/DetailCards.tsx
@@ -7,6 +7,8 @@ import { LocalizationContext } from 'src/context/Localization/LocContext';
 import ThemedSvg from 'src/components/ThemedSvg.tsx/ThemedSvg';
 import { EntityKind } from 'src/services/wallets/enums';
 import { CommonActions, useNavigation } from '@react-navigation/native';
+import { hasDoNotSpendUTXOs } from 'src/services/wallets/operations/spendability';
+import { useAppSelector } from 'src/store/hooks';
 
 interface Props {
   setShowMore?: (value: boolean) => void;
@@ -29,6 +31,10 @@ const DetailCards = ({
   const { translations } = useContext(LocalizationContext);
   const { usdtWalletText, buyBTC: buyBTCText, common } = translations;
   const navigation = useNavigation();
+  const utxoSpendability = useAppSelector((state) => state.utxos.spendability);
+  const spendabilityMap = wallet
+    ? new Map(Object.entries(utxoSpendability[wallet.id] || {}))
+    : new Map();
 
   const CardsData = [
     {
@@ -75,6 +81,13 @@ const DetailCards = ({
           : setShowMore?.(true);
       },
       disableOption: false,
+      showDot:
+        wallet?.entityKind === EntityKind.WALLET
+          ? hasDoNotSpendUTXOs(spendabilityMap, [
+              ...wallet.specs.confirmedUTXOs,
+              ...wallet.specs.unconfirmedUTXOs,
+            ])
+          : false,
     },
   ].filter(Boolean);
 
@@ -85,7 +98,7 @@ const DetailCards = ({
 
   return (
     <Box style={styles.container} backgroundColor="transparent">
-      {CardsData.map(({ id, icon: Icon, title, callback, disableOption }) => (
+      {CardsData.map(({ id, icon: Icon, title, callback, disableOption, showDot }) => (
         <TouchableOpacity
           key={id}
           onPress={callback}
@@ -102,6 +115,7 @@ const DetailCards = ({
             <Text fontSize={11} style={styles.title} numberOfLines={2} ellipsizeMode="tail">
               {title}
             </Text>
+            {showDot ? <Box style={styles.redDot} /> : null}
           </Box>
         </TouchableOpacity>
       ))}
@@ -136,5 +150,14 @@ const styles = StyleSheet.create({
     marginTop: 8,
     textAlign: 'center',
     maxWidth: '100%',
+  },
+  redDot: {
+    position: 'absolute',
+    right: 10,
+    top: 10,
+    width: 8,
+    height: 8,
+    borderRadius: 10,
+    backgroundColor: '#F72E2C',
   },
 });

--- a/src/screens/WalletDetails/components/WalletDetailHeader.tsx
+++ b/src/screens/WalletDetails/components/WalletDetailHeader.tsx
@@ -22,6 +22,7 @@ interface Props {
   totalBalance?: number;
   allowHideBalance?: boolean;
   wallet?: any;
+  showDoNotSpendInfo?: boolean;
 }
 
 const WalletDetailHeader = ({
@@ -35,6 +36,7 @@ const WalletDetailHeader = ({
   totalBalance,
   allowHideBalance,
   wallet,
+  showDoNotSpendInfo = false,
 }: Props) => {
   const navigation = useNavigation();
   return (
@@ -76,6 +78,11 @@ const WalletDetailHeader = ({
             <Text semiBold color={Colors.headerWhite} style={styles.title}>
               {title}
             </Text>
+            {showDoNotSpendInfo ? (
+              <Text color={Colors.headerWhite} style={styles.doNotSpendInfo}>
+                Includes Do Not Spend coins
+              </Text>
+            ) : null}
           </Box>
           <Box style={styles.bottomRight}>
             <BalanceComponent
@@ -134,6 +141,11 @@ const styles = StyleSheet.create({
   description: {
     fontSize: 14,
     marginBottom: hp(5),
+  },
+  doNotSpendInfo: {
+    fontSize: 12,
+    marginTop: hp(4),
+    opacity: 0.95,
   },
   bottomRight: {
     justifyContent: 'flex-end',

--- a/src/services/wallets/interfaces/index.ts
+++ b/src/services/wallets/interfaces/index.ts
@@ -133,12 +133,27 @@ export interface UTXO {
   height: number;
 }
 
+export enum UTXOSpendabilityStatus {
+  SPENDABLE = 'SPENDABLE',
+  DO_NOT_SPEND = 'DO_NOT_SPEND',
+}
+
+export enum UTXOSpendabilityReason {
+  POTENTIAL_DUST_PAYMENT = 'POTENTIAL_DUST_PAYMENT',
+  LINKED_TO_POTENTIAL_DUST_SPEND = 'LINKED_TO_POTENTIAL_DUST_SPEND',
+  MARKED_MANUALLY = 'MARKED_MANUALLY',
+}
+
 export interface UTXOInfo {
   id: string;
   txId: string;
   vout: number;
   walletId: string;
   labels?: Array<{ name: string; type: LabelType }>;
+  spendabilityStatus?: UTXOSpendabilityStatus;
+  spendabilityReason?: UTXOSpendabilityReason;
+  isUserOverride?: boolean;
+  dustToastShown?: boolean;
 }
 
 export interface BIP329Label {

--- a/src/services/wallets/interfaces/vault.ts
+++ b/src/services/wallets/interfaces/vault.ts
@@ -12,7 +12,7 @@ import {
   XpubTypes,
 } from '../enums';
 
-import { AddressCache, AddressPubs, WalletPresentationData } from './wallet';
+import { AddressCache, AddressPubs, AddressReceiveMetadata, WalletPresentationData } from './wallet';
 import { KeyInfo, KeyInfoMap, Path, Phase } from '../operations/miniscript/policy-generator';
 
 export interface VaultPresentationData extends WalletPresentationData {}
@@ -25,6 +25,7 @@ export interface VaultSpecs {
   receivingAddress?: string; // current receiving address(external chain)
   addresses?: AddressCache; // cached addresses
   addressPubs?: AddressPubs; // cached pubs
+  addressReceiveMetadata?: AddressReceiveMetadata; // cached receive history used for dust classification
   confirmedUTXOs: UTXO[]; // utxo set available for use
   unconfirmedUTXOs: UTXO[]; // utxos to arrive
   balances: Balances; // confirmed/unconfirmed balances

--- a/src/services/wallets/interfaces/wallet.ts
+++ b/src/services/wallets/interfaces/wallet.ts
@@ -36,6 +36,12 @@ export interface AddressPubs {
   [address: string]: string; // address to pub matching
 }
 
+export interface AddressReceiveMetadata {
+  highestReceivedReceiveAddressIndex: number;
+  receiveAddressReceiveCount: { [address: string]: number };
+  changeAddressReceiveCount: { [address: string]: number };
+}
+
 export interface WalletSpecs {
   xpub: string | null; // wallet's xpub
   xpriv?: string | null; // wallet's xpriv(not available for read-only wallets)
@@ -45,6 +51,7 @@ export interface WalletSpecs {
   receivingAddress?: string; // current receiving address(external chain)
   addresses?: AddressCache; // cached addresses
   addressPubs?: AddressPubs; // cached pubs
+  addressReceiveMetadata?: AddressReceiveMetadata; // cached receive history used for dust classification
   confirmedUTXOs: UTXO[]; // utxo set available for use
   unconfirmedUTXOs: UTXO[]; // utxos to arrive
   balances: Balances; // confirmed/unconfirmed balances

--- a/src/services/wallets/operations/index.ts
+++ b/src/services/wallets/operations/index.ts
@@ -62,6 +62,11 @@ import { store } from 'src/store/store';
 import BIP32Factory from 'bip32';
 const bip32 = BIP32Factory(ecc);
 import bitcoinMessage from 'bitcoinjs-message';
+import {
+  filterSpendableUTXOs,
+  normalizeAddressReceiveMetadata,
+  updateAddressReceiveMetadata,
+} from './spendability';
 
 bitcoinJS.initEccLib(ecc);
 
@@ -504,6 +509,9 @@ export default class WalletOperations {
         internal: wallet.specs.addresses?.internal || {},
       };
       const addressPubs: AddressPubs = wallet.specs.addressPubs || {};
+      let addressReceiveMetadata = normalizeAddressReceiveMetadata(
+        wallet.specs.addressReceiveMetadata
+      );
       let balances: Balances = {
         confirmed: 0,
         unconfirmed: 0,
@@ -638,6 +646,13 @@ export default class WalletOperations {
           ),
           network
         );
+
+        addressReceiveMetadata = updateAddressReceiveMetadata({
+          metadata: addressReceiveMetadata,
+          externalAddresses,
+          internalAddresses,
+          utxosByAddress,
+        });
 
         for (const address in utxosByAddress) {
           const utxos = utxosByAddress[address];
@@ -780,6 +795,7 @@ export default class WalletOperations {
         wallet.specs.totalExternalAddresses = totalExternalAddresses;
         wallet.specs.addresses = addressCache;
         wallet.specs.addressPubs = addressPubs;
+        wallet.specs.addressReceiveMetadata = addressReceiveMetadata;
         wallet.specs.receivingAddress =
           WalletOperations.getNextFreeExternalAddress(wallet).receivingAddress;
         wallet.specs.hasNewUpdates = walletHasNewUpdates;
@@ -1013,7 +1029,10 @@ export default class WalletOperations {
     if (selectedUTXOs && selectedUTXOs.length) {
       inputUTXOs = selectedUTXOs;
     } else {
-      inputUTXOs = [...wallet.specs.confirmedUTXOs, ...wallet.specs.unconfirmedUTXOs];
+      inputUTXOs = filterSpendableUTXOs(wallet.id, [
+        ...wallet.specs.confirmedUTXOs,
+        ...wallet.specs.unconfirmedUTXOs,
+      ]);
     }
 
     inputUTXOs = updateInputsForFeeCalculation(wallet, inputUTXOs, miniscriptSelectedSatisfier);
@@ -1098,7 +1117,10 @@ export default class WalletOperations {
     if (selectedUTXOs && selectedUTXOs.length) {
       inputUTXOs = selectedUTXOs;
     } else {
-      inputUTXOs = [...wallet.specs.confirmedUTXOs, ...wallet.specs.unconfirmedUTXOs];
+      inputUTXOs = filterSpendableUTXOs(wallet.id, [
+        ...wallet.specs.confirmedUTXOs,
+        ...wallet.specs.unconfirmedUTXOs,
+      ]);
     }
 
     inputUTXOs = updateInputsForFeeCalculation(wallet, inputUTXOs, miniscriptSelectedSatisfier);
@@ -1267,7 +1289,10 @@ export default class WalletOperations {
     if (selectedUTXOs && selectedUTXOs.length) {
       inputUTXOs = selectedUTXOs;
     } else {
-      inputUTXOs = [...wallet.specs.confirmedUTXOs, ...wallet.specs.unconfirmedUTXOs];
+      inputUTXOs = filterSpendableUTXOs(wallet.id, [
+        ...wallet.specs.confirmedUTXOs,
+        ...wallet.specs.unconfirmedUTXOs,
+      ]);
     }
 
     inputUTXOs = updateInputsForFeeCalculation(wallet, inputUTXOs, miniscriptSelectedSatisfier);

--- a/src/services/wallets/operations/spendability.ts
+++ b/src/services/wallets/operations/spendability.ts
@@ -1,0 +1,128 @@
+import {
+  UTXO,
+  UTXOInfo,
+  UTXOSpendabilityReason,
+  UTXOSpendabilityStatus,
+} from '../interfaces';
+import { AddressReceiveMetadata } from '../interfaces/wallet';
+
+export const DUST_THRESHOLD_SATS = 5000;
+export const MIN_DONATE_DUST_FEE_RATE = 1;
+export const DONATE_DUST_DESTINATION = 'bc1qyqequr0824nwf7snzvq5gqsr6xscn62e3ttm06';
+export const DONATE_DUST_UNBUILDABLE_ERROR =
+  'These coins are too small to donate on their own. Keeper will keep them marked Do Not Spend.';
+
+export const getUTXOId = ({ txId, vout }: Pick<UTXO, 'txId' | 'vout'>) => `${txId}:${vout}`;
+
+export const filterSpendableUTXOs = (spendabilityMap: Map<string, UTXOInfo>, utxos: UTXO[]) =>
+  utxos.filter((utxo) => {
+    const record = spendabilityMap.get(getUTXOId(utxo));
+    return !record || record.spendabilityStatus !== UTXOSpendabilityStatus.DO_NOT_SPEND;
+  });
+
+export const getDoNotSpendUTXOs = (spendabilityMap: Map<string, UTXOInfo>, utxos: UTXO[]) =>
+  utxos.filter((utxo) => {
+    const record = spendabilityMap.get(getUTXOId(utxo));
+    return record?.spendabilityStatus === UTXOSpendabilityStatus.DO_NOT_SPEND;
+  });
+
+export const hasDoNotSpendUTXOs = (spendabilityMap: Map<string, UTXOInfo>, utxos: UTXO[]) =>
+  getDoNotSpendUTXOs(spendabilityMap, utxos).length > 0;
+
+export const getSpendableBalance = (spendabilityMap: Map<string, UTXOInfo>, utxos: UTXO[]) =>
+  filterSpendableUTXOs(spendabilityMap, utxos).reduce((sum, utxo) => sum + utxo.value, 0);
+
+export const getTotalBalance = (utxos: UTXO[]) => utxos.reduce((sum, utxo) => sum + utxo.value, 0);
+
+export const normalizeAddressReceiveMetadata = (
+  metadata?: Partial<AddressReceiveMetadata>
+): AddressReceiveMetadata => ({
+  highestReceivedReceiveAddressIndex:
+    typeof metadata?.highestReceivedReceiveAddressIndex === 'number'
+      ? metadata.highestReceivedReceiveAddressIndex
+      : -1,
+  receiveAddressReceiveCount: metadata?.receiveAddressReceiveCount || {},
+  changeAddressReceiveCount: metadata?.changeAddressReceiveCount || {},
+});
+
+export const updateAddressReceiveMetadata = ({
+  metadata,
+  externalAddresses,
+  internalAddresses,
+  utxosByAddress,
+}: {
+  metadata?: Partial<AddressReceiveMetadata>;
+  externalAddresses: { [address: string]: number };
+  internalAddresses: { [address: string]: number };
+  utxosByAddress: { [address: string]: UTXO[] };
+}): AddressReceiveMetadata => {
+  const normalized = normalizeAddressReceiveMetadata(metadata);
+
+  for (const address in utxosByAddress) {
+    const receivedCount = utxosByAddress[address]?.length || 0;
+    if (receivedCount <= 0) continue;
+
+    if (externalAddresses[address] !== undefined) {
+      normalized.receiveAddressReceiveCount[address] = receivedCount;
+      if (externalAddresses[address] > normalized.highestReceivedReceiveAddressIndex) {
+        normalized.highestReceivedReceiveAddressIndex = externalAddresses[address];
+      }
+      continue;
+    }
+
+    if (internalAddresses[address] !== undefined) {
+      normalized.changeAddressReceiveCount[address] = receivedCount;
+    }
+  }
+
+  return normalized;
+};
+
+export const classifyUTXOForDust = ({
+  utxo,
+  externalAddresses,
+  internalAddresses,
+  addressReceiveMetadata,
+}: {
+  utxo: UTXO;
+  externalAddresses: { [address: string]: number };
+  internalAddresses: { [address: string]: number };
+  addressReceiveMetadata?: Partial<AddressReceiveMetadata>;
+}): {
+  spendabilityStatus: UTXOSpendabilityStatus;
+  spendabilityReason?: UTXOSpendabilityReason;
+} => {
+  if (utxo.value >= DUST_THRESHOLD_SATS) {
+    return { spendabilityStatus: UTXOSpendabilityStatus.SPENDABLE };
+  }
+
+  const metadata = normalizeAddressReceiveMetadata(addressReceiveMetadata);
+
+  const receiveIndex = externalAddresses[utxo.address];
+  if (receiveIndex !== undefined) {
+    const receiveCount = metadata.receiveAddressReceiveCount[utxo.address] || 0;
+    const isReceiveAddressReused = receiveCount > 1;
+    const isReceiveAddressOutOfOrder =
+      receiveIndex < metadata.highestReceivedReceiveAddressIndex;
+
+    if (isReceiveAddressReused || isReceiveAddressOutOfOrder) {
+      return {
+        spendabilityStatus: UTXOSpendabilityStatus.DO_NOT_SPEND,
+        spendabilityReason: UTXOSpendabilityReason.POTENTIAL_DUST_PAYMENT,
+      };
+    }
+  }
+
+  const changeIndex = internalAddresses[utxo.address];
+  if (changeIndex !== undefined) {
+    const changeCount = metadata.changeAddressReceiveCount[utxo.address] || 0;
+    if (changeCount > 1) {
+      return {
+        spendabilityStatus: UTXOSpendabilityStatus.DO_NOT_SPEND,
+        spendabilityReason: UTXOSpendabilityReason.POTENTIAL_DUST_PAYMENT,
+      };
+    }
+  }
+
+  return { spendabilityStatus: UTXOSpendabilityStatus.SPENDABLE };
+};

--- a/src/storage/realm/migrations.ts
+++ b/src/storage/realm/migrations.ts
@@ -475,4 +475,20 @@ export const runRealmMigrations = ({
       }
     }
   }
+
+  if (oldRealm.schemaVersion < 107) {
+    const utxoInfos = newRealm.objects(RealmSchema.UTXOInfo) as any;
+
+    for (const utxoInfo of utxoInfos) {
+      if (!utxoInfo.spendabilityStatus) {
+        utxoInfo.spendabilityStatus = 'SPENDABLE';
+      }
+      if (utxoInfo.isUserOverride === undefined || utxoInfo.isUserOverride === null) {
+        utxoInfo.isUserOverride = false;
+      }
+      if (utxoInfo.dustToastShown === undefined || utxoInfo.dustToastShown === null) {
+        utxoInfo.dustToastShown = false;
+      }
+    }
+  }
 };

--- a/src/storage/realm/realm.ts
+++ b/src/storage/realm/realm.ts
@@ -10,7 +10,7 @@ export class RealmDatabase {
 
   public static file = REALM_FILE;
 
-  public static schemaVersion = 106;
+  public static schemaVersion = 107;
 
   /**
    * initializes/opens realm w/ appropriate configuration

--- a/src/storage/realm/schema/vault.ts
+++ b/src/storage/realm/schema/vault.ts
@@ -224,6 +224,7 @@ export const VaultSpecsSchema: ObjectSchema = {
     receivingAddress: 'string?',
     addresses: `${RealmSchema.AddressCache}?`,
     addressPubs: 'mixed?',
+    addressReceiveMetadata: 'mixed?',
     confirmedUTXOs: `${RealmSchema.UTXO}[]`,
     unconfirmedUTXOs: `${RealmSchema.UTXO}[]`,
     balances: `${RealmSchema.Balances}`,

--- a/src/storage/realm/schema/wallet.ts
+++ b/src/storage/realm/schema/wallet.ts
@@ -39,6 +39,10 @@ export const UTXOInfoSchema: ObjectSchema = {
     vout: 'int',
     walletId: 'string',
     labels: { type: 'list', objectType: `${RealmSchema.Label}` },
+    spendabilityStatus: { type: 'string', default: 'SPENDABLE' },
+    spendabilityReason: 'string?',
+    isUserOverride: { type: 'bool', default: false },
+    dustToastShown: { type: 'bool', default: false },
   },
   primaryKey: 'id',
 };
@@ -128,6 +132,7 @@ export const WalletSpecsSchema: ObjectSchema = {
     receivingAddress: 'string?',
     addresses: `${RealmSchema.AddressCache}?`,
     addressPubs: 'mixed?',
+    addressReceiveMetadata: 'mixed?',
     confirmedUTXOs: `${RealmSchema.UTXO}[]`,
     unconfirmedUTXOs: `${RealmSchema.UTXO}[]`,
     balances: { type: 'object', objectType: RealmSchema.Balances },

--- a/src/store/reducers/utxos.ts
+++ b/src/store/reducers/utxos.ts
@@ -1,13 +1,16 @@
 import { createSlice } from '@reduxjs/toolkit';
 import { reduxStorage } from 'src/storage';
 import { persistReducer } from 'redux-persist';
+import { UTXOInfo } from 'src/services/wallets/interfaces';
 
 const initialState: {
   syncingUTXOs: boolean;
   apiError: any;
+  spendability: { [walletId: string]: Record<string, UTXOInfo> };
 } = {
   syncingUTXOs: false,
   apiError: null,
+  spendability: {},
 };
 
 const utxoSlice = createSlice({
@@ -23,10 +26,17 @@ const utxoSlice = createSlice({
     resetState: (state) => {
       state = initialState;
     },
+    setWalletSpendabilityMap: (
+      state,
+      action: { payload: { walletId: string; map: Record<string, UTXOInfo> } }
+    ) => {
+      state.spendability[action.payload.walletId] = action.payload.map;
+    },
   },
 });
 
-export const { setSyncingUTXOs, setSyncingUTXOError, resetState } = utxoSlice.actions;
+export const { setSyncingUTXOs, setSyncingUTXOError, resetState, setWalletSpendabilityMap } =
+  utxoSlice.actions;
 
 const utxoPersistConfig = {
   key: 'utxos',

--- a/src/store/sagaActions/send_and_receive.ts
+++ b/src/store/sagaActions/send_and_receive.ts
@@ -146,6 +146,7 @@ export interface CalculateCustomFeeAction extends Action {
     customEstimatedBlocks: string;
     selectedUTXOs?: UTXO[];
     miniscriptSelectedSatisfier?: MiniscriptTxSelectedSatisfier;
+    donateDustMode?: boolean;
   };
 }
 
@@ -159,6 +160,7 @@ export const calculateCustomFee = (payload: {
   customEstimatedBlocks: string;
   selectedUTXOs?: UTXO[];
   miniscriptSelectedSatisfier?: MiniscriptTxSelectedSatisfier;
+  donateDustMode?: boolean;
 }): CalculateCustomFeeAction => ({
   type: CALCULATE_CUSTOM_FEE,
   payload,

--- a/src/store/sagaActions/utxos.ts
+++ b/src/store/sagaActions/utxos.ts
@@ -1,4 +1,4 @@
-import { UTXO } from 'src/services/wallets/interfaces';
+import { UTXO, UTXOSpendabilityReason, UTXOSpendabilityStatus } from 'src/services/wallets/interfaces';
 import { Vault } from 'src/services/wallets/interfaces/vault';
 import { Wallet } from 'src/services/wallets/interfaces/wallet';
 
@@ -6,6 +6,7 @@ import { Wallet } from 'src/services/wallets/interfaces/wallet';
 export const ADD_LABELS = 'ADD_LABELS';
 export const BULK_UPDATE_LABELS = 'BULK_UPDATE_LABELS';
 export const IMPORT_LABELS = 'IMPORT_LABELS';
+export const UPDATE_UTXO_SPENDABILITY = 'UPDATE_UTXO_SPENDABILITY';
 
 export const addLabels = (payload: {
   txId: string;
@@ -45,3 +46,38 @@ export const importLabels = (payload: {
   type: IMPORT_LABELS,
   payload,
 });
+
+export const updateUTXOSpendability = (payload: {
+  walletId: string;
+  utxo: { txId: string; vout: number };
+  spendabilityStatus: UTXOSpendabilityStatus;
+  spendabilityReason?: UTXOSpendabilityReason;
+  isUserOverride?: boolean;
+  dustToastShown?: boolean;
+}) => ({
+  type: UPDATE_UTXO_SPENDABILITY,
+  payload,
+});
+
+export const markDoNotSpendUTXO = (payload: {
+  walletId: string;
+  utxo: { txId: string; vout: number };
+}) =>
+  updateUTXOSpendability({
+    walletId: payload.walletId,
+    utxo: payload.utxo,
+    spendabilityStatus: UTXOSpendabilityStatus.DO_NOT_SPEND,
+    spendabilityReason: UTXOSpendabilityReason.MARKED_MANUALLY,
+    isUserOverride: true,
+  });
+
+export const markSpendableUTXO = (payload: {
+  walletId: string;
+  utxo: { txId: string; vout: number };
+}) =>
+  updateUTXOSpendability({
+    walletId: payload.walletId,
+    utxo: payload.utxo,
+    spendabilityStatus: UTXOSpendabilityStatus.SPENDABLE,
+    isUserOverride: true,
+  });

--- a/src/store/sagas/index.ts
+++ b/src/store/sagas/index.ts
@@ -64,7 +64,12 @@ import {
   setupKeeperAppWatcher,
 } from './storage';
 import { migrateLablesWatcher, updateVersionHistoryWatcher } from './upgrade';
-import { addLabelsWatcher, bulkUpdateLabelWatcher, importLabelsWatcher } from './utxos';
+import {
+  addLabelsWatcher,
+  bulkUpdateLabelWatcher,
+  importLabelsWatcher,
+  updateUTXOSpendabilityWatcher,
+} from './utxos';
 import { connectToNodeWatcher } from './network';
 import {
   loadConciergeUserWatcher,
@@ -163,6 +168,7 @@ const rootSaga = function* () {
     addLabelsWatcher,
     bulkUpdateLabelWatcher,
     importLabelsWatcher,
+    updateUTXOSpendabilityWatcher,
     // concierge
     loadConciergeUserWatcher,
     addTicketStatusUAIWatcher,

--- a/src/store/sagas/send_and_receive.ts
+++ b/src/store/sagas/send_and_receive.ts
@@ -47,6 +47,7 @@ import { dropTransactionSnapshot } from '../reducers/cachedTxn';
 import * as bitcoin from 'bitcoinjs-lib';
 import axios from 'axios';
 import { setHomeToastMessage } from '../reducers/bhr';
+import { DONATE_DUST_UNBUILDABLE_ERROR } from 'src/services/wallets/operations/spendability';
 const EX_RATE_API = 'https://api.coingecko.com/api/v3/exchange_rates';
 
 export function* fetchFeeRatesWorker() {
@@ -394,6 +395,7 @@ function* calculateCustomFee({ payload }: CalculateCustomFeeAction) {
       customEstimatedBlocks,
       selectedUTXOs,
       miniscriptSelectedSatisfier,
+      donateDustMode,
     } = payload;
 
     let outputs;
@@ -447,7 +449,9 @@ function* calculateCustomFee({ payload }: CalculateCustomFeeAction) {
       yield put(
         customFeeCalculated({
           successful: false,
-          err: 'Fee is too high for your balance, please select another option',
+          err: donateDustMode
+            ? DONATE_DUST_UNBUILDABLE_ERROR
+            : 'Fee is too high for your balance, please select another option',
         })
       );
     }

--- a/src/store/sagas/utxos.ts
+++ b/src/store/sagas/utxos.ts
@@ -14,7 +14,11 @@ import { generateAbbreviatedOutputDescriptors } from 'src/utils/service-utilitie
 import { Vault } from 'src/services/wallets/interfaces/vault';
 import { KeeperApp } from 'src/models/interfaces/KeeperApp';
 import { createWatcher } from '../utilities';
-import { upsertWalletUTXOSpendability } from 'src/services/wallets/operations/spendability';
+import {
+  loadWalletSpendabilityMap,
+  spendabilityMapToRecord,
+  upsertUTXOSpendabilityToDb,
+} from './wallets';
 
 import {
   ADD_LABELS,
@@ -22,7 +26,7 @@ import {
   IMPORT_LABELS,
   UPDATE_UTXO_SPENDABILITY,
 } from '../sagaActions/utxos';
-import { resetState, setSyncingUTXOError, setSyncingUTXOs } from '../reducers/utxos';
+import { resetState, setSyncingUTXOError, setSyncingUTXOs, setWalletSpendabilityMap } from '../reducers/utxos';
 import { checkBackupCondition, setServerBackupFailed } from './bhr';
 import { encrypt, generateEncryptionKey, hash256 } from 'src/utils/service-utilities/encryption';
 
@@ -225,7 +229,7 @@ export function* updateUTXOSpendabilityWorker({
   try {
     yield put(setSyncingUTXOs(true));
 
-    yield call(upsertWalletUTXOSpendability, {
+    yield call(upsertUTXOSpendabilityToDb, {
       walletId: payload.walletId,
       utxo: payload.utxo,
       spendabilityStatus: payload.spendabilityStatus,
@@ -233,6 +237,14 @@ export function* updateUTXOSpendabilityWorker({
       isUserOverride: payload.isUserOverride,
       dustToastShown: payload.dustToastShown,
     });
+
+    const updatedMap = loadWalletSpendabilityMap(payload.walletId);
+    yield put(
+      setWalletSpendabilityMap({
+        walletId: payload.walletId,
+        map: spendabilityMapToRecord(updatedMap),
+      })
+    );
 
     yield put(resetState());
   } catch (e) {

--- a/src/store/sagas/utxos.ts
+++ b/src/store/sagas/utxos.ts
@@ -1,7 +1,12 @@
 import dbManager from 'src/storage/realm/dbManager';
 import { RealmSchema } from 'src/storage/realm/enum';
 import { call, delay, fork, put } from 'redux-saga/effects';
-import { BIP329Label, UTXO } from 'src/services/wallets/interfaces';
+import {
+  BIP329Label,
+  UTXO,
+  UTXOSpendabilityReason,
+  UTXOSpendabilityStatus,
+} from 'src/services/wallets/interfaces';
 import { LabelRefType } from 'src/services/wallets/enums';
 import Relay from 'src/services/backend/Relay';
 import { Wallet } from 'src/services/wallets/interfaces/wallet';
@@ -9,8 +14,14 @@ import { generateAbbreviatedOutputDescriptors } from 'src/utils/service-utilitie
 import { Vault } from 'src/services/wallets/interfaces/vault';
 import { KeeperApp } from 'src/models/interfaces/KeeperApp';
 import { createWatcher } from '../utilities';
+import { upsertWalletUTXOSpendability } from 'src/services/wallets/operations/spendability';
 
-import { ADD_LABELS, BULK_UPDATE_LABELS, IMPORT_LABELS } from '../sagaActions/utxos';
+import {
+  ADD_LABELS,
+  BULK_UPDATE_LABELS,
+  IMPORT_LABELS,
+  UPDATE_UTXO_SPENDABILITY,
+} from '../sagaActions/utxos';
 import { resetState, setSyncingUTXOError, setSyncingUTXOs } from '../reducers/utxos';
 import { checkBackupCondition, setServerBackupFailed } from './bhr';
 import { encrypt, generateEncryptionKey, hash256 } from 'src/utils/service-utilities/encryption';
@@ -199,6 +210,42 @@ export function* importLabelsWorker({
   }
 }
 
+export function* updateUTXOSpendabilityWorker({
+  payload,
+}: {
+  payload: {
+    walletId: string;
+    utxo: { txId: string; vout: number };
+    spendabilityStatus: UTXOSpendabilityStatus;
+    spendabilityReason?: UTXOSpendabilityReason;
+    isUserOverride?: boolean;
+    dustToastShown?: boolean;
+  };
+}) {
+  try {
+    yield put(setSyncingUTXOs(true));
+
+    yield call(upsertWalletUTXOSpendability, {
+      walletId: payload.walletId,
+      utxo: payload.utxo,
+      spendabilityStatus: payload.spendabilityStatus,
+      spendabilityReason: payload.spendabilityReason,
+      isUserOverride: payload.isUserOverride,
+      dustToastShown: payload.dustToastShown,
+    });
+
+    yield put(resetState());
+  } catch (e) {
+    yield put(setSyncingUTXOError(e));
+  } finally {
+    yield put(setSyncingUTXOs(false));
+  }
+}
+
 export const addLabelsWatcher = createWatcher(addLabelsWorker, ADD_LABELS);
 export const bulkUpdateLabelWatcher = createWatcher(bulkUpdateLabelsWorker, BULK_UPDATE_LABELS);
 export const importLabelsWatcher = createWatcher(importLabelsWorker, IMPORT_LABELS);
+export const updateUTXOSpendabilityWatcher = createWatcher(
+  updateUTXOSpendabilityWorker,
+  UPDATE_UTXO_SPENDABILITY
+);

--- a/src/store/sagas/wallets.ts
+++ b/src/store/sagas/wallets.ts
@@ -40,6 +40,10 @@ import { RealmSchema } from 'src/storage/realm/enum';
 import Relay from 'src/services/backend/Relay';
 import SigningServer from 'src/services/backend/SigningServer';
 import WalletOperations from 'src/services/wallets/operations';
+import {
+  classifyUTXOForDust,
+  getUTXOId,
+} from 'src/services/wallets/operations/spendability';
 import WalletUtilities from 'src/services/wallets/operations/utils';
 import { createWatcher } from 'src/store/utilities';
 import dbManager from 'src/storage/realm/dbManager';
@@ -61,10 +65,71 @@ import ElectrumClient, {
 } from 'src/services/electrum/client';
 import idx from 'idx';
 import _ from 'lodash';
-import { SyncedWallet } from 'src/services/wallets/interfaces';
+import {
+  SyncedWallet,
+  UTXO,
+  UTXOInfo,
+  UTXOSpendabilityReason,
+  UTXOSpendabilityStatus,
+} from 'src/services/wallets/interfaces';
 import { checkSignerAccountsMatch, getAccountFromSigner, getKeyUID } from 'src/utils/utilities';
 import { COLLABORATIVE_SCHEME } from 'src/screens/SigningDevices/SetupCollaborativeWallet';
 import { RootState } from '../store';
+
+const normalizeUTXOInfo = (record: any): UTXOInfo =>
+  typeof record?.toJSON === 'function' ? record.toJSON() : record;
+
+export const loadWalletSpendabilityRecords = (walletId: string): UTXOInfo[] => {
+  const records = dbManager.getObjectByField(RealmSchema.UTXOInfo, walletId, 'walletId') as any;
+  if (!records) return [];
+  if (Array.isArray(records)) return records.map(normalizeUTXOInfo);
+  const normalized: UTXOInfo[] = [];
+  if (typeof records.forEach === 'function') {
+    records.forEach((record) => normalized.push(normalizeUTXOInfo(record)));
+  }
+  return normalized;
+};
+
+export const loadWalletSpendabilityMap = (walletId: string): Map<string, UTXOInfo> => {
+  const map = new Map<string, UTXOInfo>();
+  loadWalletSpendabilityRecords(walletId).forEach((record) => map.set(record.id, record));
+  return map;
+};
+
+export const spendabilityMapToRecord = (map: Map<string, UTXOInfo>): Record<string, UTXOInfo> => {
+  const record: Record<string, UTXOInfo> = {};
+  map.forEach((value, key) => { record[key] = value; });
+  return record;
+};
+
+export const upsertUTXOSpendabilityToDb = ({
+  walletId,
+  utxo,
+  spendabilityStatus = UTXOSpendabilityStatus.SPENDABLE,
+  spendabilityReason,
+  isUserOverride = false,
+  dustToastShown = false,
+}: {
+  walletId: string;
+  utxo: Pick<UTXO, 'txId' | 'vout'>;
+  spendabilityStatus?: UTXOSpendabilityStatus;
+  spendabilityReason?: UTXOSpendabilityReason;
+  isUserOverride?: boolean;
+  dustToastShown?: boolean;
+}) => {
+  const id = getUTXOId(utxo);
+  return dbManager.createObject(RealmSchema.UTXOInfo, {
+    id,
+    txId: utxo.txId,
+    vout: utxo.vout,
+    walletId,
+    labels: [],
+    spendabilityStatus,
+    spendabilityReason,
+    isUserOverride,
+    dustToastShown,
+  });
+};
 
 import {
   initiateVaultMigration,
@@ -109,6 +174,7 @@ import {
   updateAppImageWorker,
   updateVaultImageWorker,
 } from './bhr';
+import { setHomeToastMessage } from '../reducers/bhr';
 import {
   relaySignersUpdateFail,
   relaySignersUpdateSuccess,
@@ -128,6 +194,7 @@ import { setElectrumNotConnectedErr } from '../reducers/login';
 import { connectToNodeWorker } from './network';
 import { backupBsmsOnCloud } from '../sagaActions/bhr';
 import { bulkUpdateLabelsWorker } from './utxos';
+import { setWalletSpendabilityMap } from '../reducers/utxos';
 import { updateDelayedPolicyUpdate } from '../reducers/storage';
 import { accountNoFromDerivationPath } from 'src/utils/service-utilities/utils';
 
@@ -650,6 +717,151 @@ function* refreshWalletsWorker({
     for (const synchedWalletWithUTXOs of synchedWallets) {
       const { synchedWallet } = synchedWalletWithUTXOs;
       if (!synchedWallet.specs.hasNewUpdates && !options.hardRefresh) continue; // no new updates found
+
+      const spendabilityMap = loadWalletSpendabilityMap(synchedWallet.id);
+      const externalAddresses = {};
+      const internalAddresses = {};
+
+      Object.entries(synchedWallet.specs.addresses?.external || {}).forEach(([index, address]) => {
+        externalAddresses[address as string] = parseInt(index, 10);
+      });
+
+      Object.entries(synchedWallet.specs.addresses?.internal || {}).forEach(([index, address]) => {
+        internalAddresses[address as string] = parseInt(index, 10);
+      });
+
+      const currentUTXOs = [
+        ...synchedWallet.specs.confirmedUTXOs,
+        ...synchedWallet.specs.unconfirmedUTXOs,
+      ];
+      let shouldShowDustToast = false;
+
+      for (const utxo of currentUTXOs) {
+        const utxoId = getUTXOId(utxo);
+        if (spendabilityMap.has(utxoId)) continue;
+
+        const classification = classifyUTXOForDust({
+          utxo,
+          externalAddresses,
+          internalAddresses,
+          addressReceiveMetadata: synchedWallet.specs.addressReceiveMetadata,
+        });
+
+        const isPotentialDustPayment =
+          classification.spendabilityReason === 'POTENTIAL_DUST_PAYMENT';
+        const shouldMarkToastShown = options.addNotifications && isPotentialDustPayment;
+        if (shouldMarkToastShown) {
+          shouldShowDustToast = true;
+        }
+
+        upsertUTXOSpendabilityToDb({
+          walletId: synchedWallet.id,
+          utxo,
+          spendabilityStatus: classification.spendabilityStatus,
+          spendabilityReason: classification.spendabilityReason,
+          isUserOverride: false,
+          dustToastShown: shouldMarkToastShown,
+        });
+
+        spendabilityMap.set(utxoId, {
+          id: utxoId,
+          txId: utxo.txId,
+          vout: utxo.vout,
+          walletId: synchedWallet.id,
+          spendabilityStatus: classification.spendabilityStatus,
+          spendabilityReason: classification.spendabilityReason,
+          isUserOverride: false,
+          dustToastShown: shouldMarkToastShown,
+        });
+      }
+
+      const currentUTXOIds = new Set(currentUTXOs.map((utxo) => getUTXOId(utxo)));
+      const spentPotentialDustRecords = Array.from(spendabilityMap.values()).filter(
+        (record) =>
+          record.spendabilityReason === UTXOSpendabilityReason.POTENTIAL_DUST_PAYMENT &&
+          !currentUTXOIds.has(record.id)
+      );
+
+      if (spentPotentialDustRecords.length) {
+        const txids = synchedWallet.specs.transactions.map((txn) => txn.txid);
+        const txMap = yield call(ElectrumClient.getTransactionsById, txids);
+
+        for (const record of spentPotentialDustRecords) {
+          const spendingTxs = Object.values(txMap || {}).filter((tx: any) =>
+            (tx.vin || []).some(
+              (vin) => vin.txid === record.txId && Number(vin.vout) === Number(record.vout)
+            )
+          );
+
+          for (const spendingTx of spendingTxs as any[]) {
+            yield fork(bulkUpdateLabelsWorker, {
+              payload: {
+                labelChanges: {
+                  added: [{ isSystem: true, name: 'Potential dust spend' }],
+                  deleted: [],
+                },
+                txId: spendingTx.txid,
+                wallet: synchedWallet as any,
+              },
+            });
+
+            (spendingTx.vout || []).forEach((output, outputIndex) => {
+              const outputAddress = output?.scriptPubKey?.addresses?.[0];
+              if (!outputAddress) return;
+
+              const isWalletOwnedOutputAddress =
+                externalAddresses[outputAddress] !== undefined ||
+                internalAddresses[outputAddress] !== undefined;
+              if (!isWalletOwnedOutputAddress) return;
+
+              const descendantId = `${spendingTx.txid}:${outputIndex}`;
+              if (!currentUTXOIds.has(descendantId)) return;
+
+              const existingRecord = spendabilityMap.get(descendantId);
+              if (existingRecord?.isUserOverride) return;
+
+              upsertUTXOSpendabilityToDb({
+                walletId: synchedWallet.id,
+                utxo: {
+                  txId: spendingTx.txid,
+                  vout: outputIndex,
+                },
+                spendabilityStatus: UTXOSpendabilityStatus.DO_NOT_SPEND,
+                spendabilityReason: UTXOSpendabilityReason.LINKED_TO_POTENTIAL_DUST_SPEND,
+                isUserOverride: false,
+                dustToastShown: true,
+              });
+
+              spendabilityMap.set(descendantId, {
+                id: descendantId,
+                txId: spendingTx.txid,
+                vout: outputIndex,
+                walletId: synchedWallet.id,
+                spendabilityStatus: UTXOSpendabilityStatus.DO_NOT_SPEND,
+                spendabilityReason: UTXOSpendabilityReason.LINKED_TO_POTENTIAL_DUST_SPEND,
+                isUserOverride: false,
+                dustToastShown: true,
+              });
+            });
+          }
+        }
+      }
+
+      if (shouldShowDustToast) {
+        yield put(
+          setHomeToastMessage({
+            message: 'Potential dust payment found',
+            isError: false,
+          })
+        );
+      }
+
+      yield put(
+        setWalletSpendabilityMap({
+          walletId: synchedWallet.id,
+          map: spendabilityMapToRecord(spendabilityMap),
+        })
+      );
 
       for (const utxo of synchedWalletWithUTXOs.newUTXOs) {
         const labelChanges = {


### PR DESCRIPTION
This pull request introduces a comprehensive privacy-focused dust attack protection system and a "Donate Dust" flow, affecting UTXO management, wallet sync, send flow, transaction history, and UI indicators. The core change is the addition of persisted UTXO spendability state with user override, ensuring suspicious low-value UTXOs are not auto-selected for spending, and providing users with clear control and visibility. The changes also include new UI feedback, migration plans, and requirements for both mainnet and testnet.

**Dust Attack Protection and UTXO Spendability Enhancements:**

- Persist a spendability state (`Spendable` or `Do Not Spend`) with reason and user override for each wallet UTXO, stored in extended UTXO metadata. Classification occurs during wallet sync/refresh, using value and address heuristics. Descendant tracing for already-spent dust is supported one level deep. 
- Manual controls in UTXO details allow users to mark UTXOs as Do Not Spend or Spendable, with reasons and override persistence. Do Not Spend status is clearly labeled in UTXO management screens, alongside existing labels.

**Send Flow and Coin Selection:**

- Automatic input selection for sends excludes Do Not Spend UTXOs; helper messaging explains when total balance is sufficient but spendable is not. Manual selection of Do Not Spend UTXOs requires explicit confirmation.
- Donate Dust flow enables users to send only Do Not Spend UTXOs to a designated address, with strict input and fee rules. Clear failure messaging is provided if donation is not possible.

**UI and Transaction History Updates:**

- Wallet list, details, and coin management screens show red-dot and subtitle indicators when Do Not Spend UTXOs are present.
- Transaction history marks and explains historical potential dust spends, but does not trigger wallet-level indicators if no current Do Not Spend UTXOs exist.

**Migration and Compatibility:**

- Realm schema is extended for new UTXO fields, with migration logic and additive/nullable rollback. No new screens or breaking changes to PSBT/hardware signer flows.
