### PR TITLE
Enhance dust report terminology and UI for better clarity

### DIFF
--- a/flows/dustAnalysisReport.yaml
+++ b/flows/dustAnalysisReport.yaml
@@ -89,7 +89,7 @@ appId: io.hexawallet.keeper
             - assertVisible: 'Keeper found coins or transactions that may reduce wallet privacy.'
             # Summary card
             - assertVisible: 'Do Not Spend coins'
-            - assertVisible: 'Amount marked Do Not Spend'
+            - assertVisible: 'Amount'
             - assertVisible: 'Past dust spends'
             - assertVisible: 'Last scanned'
             # Section headers

--- a/openspec/changes/dust-analysis-report/specs/dust-analysis-report/spec.md
+++ b/openspec/changes/dust-analysis-report/specs/dust-analysis-report/spec.md
@@ -80,7 +80,8 @@ When the scan finds at least one Active Dust UTXO, Linked Coin, or Past Dust Spe
 
 - GIVEN the scan has completed and wallet `W` has UTXOs with `dustReason === 'adjacent'` or `dustReason === 'descendant'` and `spendability === 'doNotSpend'`
 - WHEN the Linked Coins section renders
-- THEN each row displays the UTXO value in sats, the label "Do Not Spend", and the reason "Linked to potential dust spend"
+- THEN each row with `dustReason === 'adjacent'` displays the reason "Linked to potential dust payment"
+- AND each row with `dustReason === 'descendant'` displays the reason "Linked to potential dust spend"
 
 #### Scenario: Linked Coins section empty state
 

--- a/openspec/changes/dust-analysis-report/specs/dust-analysis-report/spec.md
+++ b/openspec/changes/dust-analysis-report/specs/dust-analysis-report/spec.md
@@ -59,7 +59,7 @@ When the scan finds at least one Active Dust UTXO, Linked Coin, or Past Dust Spe
 - GIVEN the scan has completed and wallet `W` has 3 UTXOs with `spendability === 'doNotSpend'` (values: 400, 600, 800 sats) and 1 transaction tagged `potential-dust-spend`
 - WHEN the report result screen renders
 - THEN the summary card shows "Do Not Spend coins: 3"
-- AND "Amount marked Do Not Spend: 1,800 sats"
+- AND "Amount: 1,800 sats"
 - AND "Past dust spends: 1"
 - AND "Last scanned" shows the timestamp written to MMKV at scan completion
 

--- a/src/context/Localization/language/en.json
+++ b/src/context/Localization/language/en.json
@@ -573,6 +573,7 @@
     "noLinkedCoins": "No linked coins found.",
     "noPastDustSpends": "No past dust spends found.",
     "potentialDustPayment": "Potential dust payment",
+    "linkedToPayment": "Linked to potential dust payment",
     "linkedToDustSpend": "Linked to potential dust spend",
     "potentialDustSpend": "Potential dust spend",
     "donateDustConfirmBody": "Donating can help clear dust / Do Not Spend coins for better privacy.",

--- a/src/context/Localization/language/en.json
+++ b/src/context/Localization/language/en.json
@@ -580,7 +580,12 @@
     "lastScannedNever": "Never",
     "runReport": "Run Report",
     "tryAgain": "Try Again",
-    "tooSmallToDonate": "Dust amount is too small to donate after fees"
+    "tooSmallToDonate": "Dust amount is too small to donate after fees",
+    "dustReportLearnMoreTitle": "About Dust Report",
+    "dustInfoWhatIs": "Dust is a very small amount of bitcoin (under 5,000 sats) sent to a wallet address to trace its activity. Spending it alongside other coins can link them on the blockchain and reduce your privacy.",
+    "dustInfoInitial": "Active Dust: A coin under 5,000 sats received on an address that has already been used before (a reused address). Spending it can reveal connections between your past and future transactions.",
+    "dustInfoAdjacent": "Linked Coins: Coins connected to dust in two ways. First, coins at the same address where dust was received (a poisoned address). Second, coins received in a transaction that spent a dust coin (a descendant coin).",
+    "dustInfoDescendant": "Past Dust Spends: Transactions in your history where a Do Not Spend coin was already used. These transactions have confirmed a link between your addresses and dust activity."
   },
   "vault": {
     "Addsigner": "Add a Signer",

--- a/src/context/Localization/language/es.json
+++ b/src/context/Localization/language/es.json
@@ -563,6 +563,7 @@
     "noLinkedCoins": "No linked coins found.",
     "noPastDustSpends": "No past dust spends found.",
     "potentialDustPayment": "Potential dust payment",
+    "linkedToPayment": "Linked to potential dust payment",
     "linkedToDustSpend": "Linked to potential dust spend",
     "potentialDustSpend": "Potential dust spend",
     "donateDustConfirmBody": "Donating can help clear dust / Do Not Spend coins for better privacy.",

--- a/src/context/Localization/language/es.json
+++ b/src/context/Localization/language/es.json
@@ -570,7 +570,12 @@
     "lastScannedNever": "Never",
     "runReport": "Run Report",
     "tryAgain": "Try Again",
-    "tooSmallToDonate": "Dust amount is too small to donate after fees"
+    "tooSmallToDonate": "Dust amount is too small to donate after fees",
+    "dustReportLearnMoreTitle": "About Dust Report",
+    "dustInfoWhatIs": "Dust is a very small amount of bitcoin (under 5,000 sats) sent to a wallet address to trace its activity. Spending it alongside other coins can link them on the blockchain and reduce your privacy.",
+    "dustInfoInitial": "Active Dust: A coin under 5,000 sats received on an address that has already been used before (a reused address). Spending it can reveal connections between your past and future transactions.",
+    "dustInfoAdjacent": "Linked Coins: Coins connected to dust in two ways. First, coins at the same address where dust was received (a poisoned address). Second, coins received in a transaction that spent a dust coin (a descendant coin).",
+    "dustInfoDescendant": "Past Dust Spends: Transactions in your history where a Do Not Spend coin was already used. These transactions have confirmed a link between your addresses and dust activity."
   },
   "vault": {
     "Addsigner": "Add a Signer",

--- a/src/screens/DustReport/DustReportScreen.tsx
+++ b/src/screens/DustReport/DustReportScreen.tsx
@@ -16,6 +16,7 @@ import { NativeStackScreenProps } from '@react-navigation/native-stack';
 import { AppStackParams } from 'src/navigation/types';
 import useDustReport from 'src/hooks/useDustReport';
 import { UTXO, Transaction } from 'src/services/wallets/interfaces';
+import moment from 'moment';
 
 type Props = NativeStackScreenProps<AppStackParams, 'DustReport'>;
 
@@ -54,6 +55,9 @@ function UTXORow({ utxo, reason }: { utxo: UTXO; reason: string }) {
         <Text color={`${colorMode}.secondaryText`} style={styles.rowReason}>
           {reason}
         </Text>
+        <Text color={`${colorMode}.secondaryText`} style={styles.rowId} numberOfLines={1}>
+          {utxo.txId}:{utxo.vout}
+        </Text>
       </Box>
       <DoNotSpendChip />
     </Box>
@@ -63,8 +67,10 @@ function UTXORow({ utxo, reason }: { utxo: UTXO; reason: string }) {
 function TxRow({ tx }: { tx: Transaction }) {
   const { colorMode } = useColorMode();
   const date = tx.blockTime
-    ? new Date(tx.blockTime * 1000).toLocaleDateString()
-    : tx.date ?? '—';
+    ? moment(tx.blockTime * 1000).format('DD MMM YY • HH:mm A')
+    : tx.date
+    ? moment(tx.date).format('DD MMM YY • HH:mm A')
+    : '—';
   return (
     <Box style={styles.row}>
       <Box style={styles.rowLeft}>
@@ -74,6 +80,9 @@ function TxRow({ tx }: { tx: Transaction }) {
         </Text>
         <Text color={`${colorMode}.secondaryText`} style={styles.rowReason}>
           Potential dust spend
+        </Text>
+        <Text color={`${colorMode}.secondaryText`} style={styles.rowId} numberOfLines={1}>
+          {tx.txid}
         </Text>
       </Box>
     </Box>
@@ -470,6 +479,12 @@ const styles = StyleSheet.create({
     fontSize: 12,
     lineHeight: 18,
     marginTop: hp(2),
+  },
+  rowId: {
+    fontSize: 11,
+    lineHeight: 16,
+    marginTop: hp(2),
+    fontFamily: 'monospace',
   },
   chip: {
     backgroundColor: 'rgba(242, 72, 34, 0.12)',

--- a/src/screens/DustReport/DustReportScreen.tsx
+++ b/src/screens/DustReport/DustReportScreen.tsx
@@ -247,7 +247,7 @@ function DustReportScreen({ route }: Props) {
                 <UTXORow
                   key={`${utxo.txId}:${utxo.vout}-${idx}`}
                   utxo={utxo}
-                  reason={t.linkedToDustSpend}
+                  reason={utxo.dustReason === 'adjacent' ? t.linkedToPayment : t.linkedToDustSpend}
                 />
               ))}
             </SectionCard>

--- a/src/screens/DustReport/DustReportScreen.tsx
+++ b/src/screens/DustReport/DustReportScreen.tsx
@@ -1,5 +1,5 @@
-import React, { useContext } from 'react';
-import { ScrollView, StyleSheet } from 'react-native';
+import React, { useContext, useState } from 'react';
+import { Pressable, ScrollView, StyleSheet } from 'react-native';
 import { Box, useColorMode } from '@gluestack-ui/themed-native-base';
 import ScreenWrapper from 'src/components/ScreenWrapper';
 import WalletHeader from 'src/components/WalletHeader';
@@ -9,6 +9,9 @@ import KeeperModal from 'src/components/KeeperModal';
 import ActivityIndicatorView from 'src/components/AppActivityIndicator/ActivityIndicatorView';
 import { hp, wp } from 'src/constants/responsive';
 import { LocalizationContext } from 'src/context/Localization/LocContext';
+import Instruction from 'src/components/Instruction';
+import ThemedColor from 'src/components/ThemedColor/ThemedColor';
+import ThemedSvg from 'src/components/ThemedSvg.tsx/ThemedSvg';
 import { NativeStackScreenProps } from '@react-navigation/native-stack';
 import { AppStackParams } from 'src/navigation/types';
 import useDustReport from 'src/hooks/useDustReport';
@@ -116,6 +119,12 @@ function DustReportScreen({ route }: Props) {
   const { translations } = useContext(LocalizationContext);
   const { wallet: t, common } = translations;
 
+  const [infoVisible, setInfoVisible] = useState(false);
+  const green_modal_text_color = ThemedColor({ name: 'green_modal_text_color' });
+  const green_modal_background = ThemedColor({ name: 'green_modal_background' });
+  const green_modal_button_background = ThemedColor({ name: 'green_modal_button_background' });
+  const green_modal_button_text = ThemedColor({ name: 'green_modal_button_text' });
+
   const {
     phase,
     progressStep,
@@ -132,6 +141,17 @@ function DustReportScreen({ route }: Props) {
 
   const progressItems = [t.scanProgressCoins, t.scanProgressTxs, t.scanProgressReport];
 
+  function infoModalContent() {
+    return (
+      <Box>
+        <Instruction textColor={green_modal_text_color} text={t.dustInfoWhatIs} />
+        <Instruction textColor={green_modal_text_color} text={t.dustInfoInitial} />
+        <Instruction textColor={green_modal_text_color} text={t.dustInfoAdjacent} />
+        <Instruction textColor={green_modal_text_color} text={t.dustInfoDescendant} />
+      </Box>
+    );
+}
+
   const screenTitle =
     phase === 'scanning'
       ? t.scanningWalletTitle
@@ -143,7 +163,14 @@ function DustReportScreen({ route }: Props) {
 
   return (
     <ScreenWrapper backgroundcolor={`${colorMode}.primaryBackground`}>
-      <WalletHeader title={screenTitle} />
+      <WalletHeader
+        title={screenTitle}
+        rightComponent={
+          <Pressable onPress={() => setInfoVisible(true)}>
+            <ThemedSvg name={'info_icon'} />
+          </Pressable>
+        }
+      />
 
       {/* ── Start phase ──────────────────────────────────────────────── */}
       {phase === 'start' && (
@@ -316,6 +343,21 @@ function DustReportScreen({ route }: Props) {
           </Box>
         </Box>
       )}
+
+      {/* ── Info / Learn More modal ──────────────────────────────────── */}
+      <KeeperModal
+        visible={infoVisible}
+        close={() => setInfoVisible(false)}
+        title={t.dustReportLearnMoreTitle}
+        modalBackground={green_modal_background}
+        textColor={green_modal_text_color}
+        Content={infoModalContent}
+        DarkCloseIcon
+        buttonText={common.Okay}
+        buttonTextColor={green_modal_button_text}
+        buttonBackground={green_modal_button_background}
+        buttonCallback={() => setInfoVisible(false)}
+      />
 
       {/* ── Donate Dust confirmation modal ───────────────────────────── */}
       <KeeperModal

--- a/src/screens/DustReport/DustReportScreen.tsx
+++ b/src/screens/DustReport/DustReportScreen.tsx
@@ -217,7 +217,7 @@ function DustReportScreen({ route }: Props) {
                 value={String(reportData.doNotSpendUTXOs.length)}
               />
               <SummaryRow
-                label="Amount marked Do Not Spend"
+                label="Amount"
                 value={`${reportData.amountMarkedDNS.toLocaleString()} sats`}
               />
               <SummaryRow

--- a/src/screens/UTXOManagement/UTXOLabeling.tsx
+++ b/src/screens/UTXOManagement/UTXOLabeling.tsx
@@ -176,6 +176,9 @@ function UTXOLabeling() {
         <LabelsEditor
           utxo={utxo}
           wallet={wallet}
+          readOnlyLabels={
+            isDoNotSpend ? [{ name: 'Do Not Spend', isSystem: true }] : []
+          }
           onLabelsSaved={() => {
             showToast(walletTranslations.LabelsSavedSuccessfully, <TickIcon />);
             navigation.goBack();

--- a/src/screens/UTXOManagement/UTXOLabeling.tsx
+++ b/src/screens/UTXOManagement/UTXOLabeling.tsx
@@ -67,7 +67,9 @@ function UTXOLabeling() {
 
   const dustReasonLabel = isManualOverride
     ? 'Marked manually'
-    : dustReason === 'descendant' || dustReason === 'adjacent'
+    : dustReason === 'adjacent'
+    ? 'Linked to potential dust payment'
+    : dustReason === 'descendant'
     ? 'Linked to potential dust spend'
     : 'Potential dust payment';
 

--- a/src/screens/UTXOManagement/components/LabelItem.tsx
+++ b/src/screens/UTXOManagement/components/LabelItem.tsx
@@ -15,6 +15,7 @@ function LabelItem({
   onLayout,
   onUnmount,
   editable = true,
+  backgroundColor: backgroundColorOverride,
 }: {
   item: { name: string; isSystem: boolean };
   index: number;
@@ -22,6 +23,7 @@ function LabelItem({
   onEditClick?: Function;
   editingIndex?: number;
   editable?: boolean;
+  backgroundColor?: string;
   onLayout?: (event, index) => void;
   onUnmount?: (index) => void;
 }) {
@@ -52,7 +54,7 @@ function LabelItem({
           onLayout(event, index);
         }
       }}
-      backgroundColor={getLabelColor(item.name)}
+      backgroundColor={backgroundColorOverride ?? getLabelColor(item.name)}
     >
       <TouchableOpacity
         style={styles.labelEditContainer}

--- a/src/screens/UTXOManagement/components/LabelsEditor.tsx
+++ b/src/screens/UTXOManagement/components/LabelsEditor.tsx
@@ -16,7 +16,13 @@ import { hp, wp } from 'src/constants/responsive';
 import { bulkUpdateLabels } from 'src/store/sagaActions/utxos';
 import { LocalizationContext } from 'src/context/Localization/LocContext';
 
-function LabelsEditor({ utxo = null, address = null, wallet, onLabelsSaved }) {
+function LabelsEditor({ utxo = null, address = null, wallet, onLabelsSaved, readOnlyLabels = [] }: {
+  utxo?: any;
+  address?: string;
+  wallet: any;
+  onLabelsSaved: () => void;
+  readOnlyLabels?: { name: string; isSystem: boolean }[];
+}) {
   const { labels } = useLabelsNew({ address, utxos: utxo ? [utxo] : [] });
   const { syncingUTXOs, apiError } = useAppSelector((state) => state.utxos);
   const { showToast } = useToastMessage();
@@ -145,8 +151,17 @@ function LabelsEditor({ utxo = null, address = null, wallet, onLabelsSaved }) {
             {label && label !== '' ? <ConfirmSquareGreen /> : <ConfirmSquare />}
           </TouchableOpacity>
         </Box>
-        {existingLabels && existingLabels.length > 0 && (
+        {(existingLabels.length > 0 || readOnlyLabels.length > 0) && (
           <View style={styles.listSubContainer}>
+            {readOnlyLabels.map((item, index) => (
+              <LabelItem
+                item={item}
+                index={index}
+                key={`readonly:${item.name}`}
+                editable={false}
+                backgroundColor={item.name === 'Do Not Spend' ? Colors.CrimsonRed : undefined}
+              />
+            ))}
             {existingLabels.map((item, index) => (
               <LabelItem
                 item={item}

--- a/src/screens/Vault/VaultDetails.tsx
+++ b/src/screens/Vault/VaultDetails.tsx
@@ -34,6 +34,7 @@ import { SentryErrorBoundary } from 'src/services/sentry';
 import ActivityIndicatorView from 'src/components/AppActivityIndicator/ActivityIndicatorView';
 import { ELECTRUM_CLIENT } from 'src/services/electrum/client';
 import useWalletAsset from 'src/hooks/useWalletAsset';
+import { useUTXOSpendability } from 'src/hooks/useUTXOSpendability';
 import ConciergeNeedHelp from 'src/assets/images/conciergeNeedHelp.svg';
 import ToastErrorIcon from 'src/assets/images/toast_error.svg';
 import MiniscriptPathSelector, {
@@ -190,6 +191,7 @@ function VaultDetails({ navigation, route }: ScreenProps) {
     ELECTRUM_CLIENT.isClientConnected && walletSyncing && vault ? !!walletSyncing[vault.id] : false;
 
   const isDarkMode = colorMode === 'dark';
+  const { hasDoNotSpendUTXOs } = useUTXOSpendability(vault ?? null);
   const { getWalletIcon, getWalletCardGradient, getWalletTags } = useWalletAsset();
   const WalletIcon = getWalletIcon(vault);
   const green_modal_text_color = ThemedColor({ name: 'green_modal_text_color' });
@@ -485,6 +487,8 @@ function VaultDetails({ navigation, route }: ScreenProps) {
           <DetailCards
             setShowMore={setShowMore}
             disabled={vault.archived}
+            wallet={vault}
+            hasDoNotSpendUTXOs={hasDoNotSpendUTXOs}
             sendCallback={async () => {
               if (timeUntilTimelockExpires) {
                 setShowTimelockModal(true);
@@ -640,6 +644,7 @@ function VaultDetails({ navigation, route }: ScreenProps) {
                   }, 300);
                 }}
                 Icon={<CoinIcon />}
+                showDot={hasDoNotSpendUTXOs}
               />
               {!isCanaryWallet && (
                 <MoreCard

--- a/src/screens/ViewTransactions/TransactionDetails.tsx
+++ b/src/screens/ViewTransactions/TransactionDetails.tsx
@@ -272,7 +272,7 @@ function TransactionDetails({ route }) {
                   Potential dust spend
                 </Text>
                 <Text style={styles.dustSpendWarningBody} color={`${colorMode}.GreyText`}>
-                  This transaction may have spent a suspicious small amount together with other
+                  This transaction has spent dust UTXO(s) together with other
                   wallet funds. This may have reduced wallet privacy.
                 </Text>
               </Box>
@@ -432,7 +432,7 @@ const styles = StyleSheet.create({
   dustSpendWarning: {
     marginHorizontal: wp(20),
     marginTop: hp(10),
-    marginBottom: hp(5),
+    marginBottom: hp(15),
     padding: wp(15),
     borderRadius: 10,
     borderWidth: 1,

--- a/src/screens/WalletDetails/components/DetailCards.tsx
+++ b/src/screens/WalletDetails/components/DetailCards.tsx
@@ -78,7 +78,7 @@ const DetailCards = ({
           : setShowMore?.(true);
       },
       disableOption: false,
-      showDot: wallet?.entityKind === EntityKind.WALLET && hasDoNotSpendUTXOs,
+      showDot: hasDoNotSpendUTXOs,
     },
   ].filter(Boolean);
 

--- a/src/screens/WalletDetails/components/MoreCard.tsx
+++ b/src/screens/WalletDetails/components/MoreCard.tsx
@@ -1,17 +1,19 @@
 import React from 'react';
 import { Box } from '@gluestack-ui/themed-native-base';
 import Text from 'src/components/KeeperText';
-import { StyleSheet, TouchableOpacity } from 'react-native';
+import { StyleSheet, TouchableOpacity, View } from 'react-native';
 import { useColorMode } from '@gluestack-ui/themed-native-base';
 import CircleIconWrapper from 'src/components/CircleIconWrapper';
+import Colors from 'src/theme/Colors';
 
 type Props = {
   Icon?: React.ReactNode;
   title?: string;
   callBack?: () => void;
+  showDot?: boolean;
 };
 
-const MoreCard = ({ Icon, title, callBack }: Props) => {
+const MoreCard = ({ Icon, title, callBack, showDot = false }: Props) => {
   const { colorMode } = useColorMode();
 
   return (
@@ -22,7 +24,10 @@ const MoreCard = ({ Icon, title, callBack }: Props) => {
         backgroundColor={`${colorMode}.primaryBackground`}
       >
         <Box style={styles.infoContainer}>
-          <CircleIconWrapper width={40} icon={Icon} backgroundColor={`${colorMode}.pantoneGreen`} />
+          <View>
+            <CircleIconWrapper width={40} icon={Icon} backgroundColor={`${colorMode}.pantoneGreen`} />
+            {showDot && <View style={styles.dot} />}
+          </View>
           <Text medium style={styles.cardName} color={`${colorMode}.primaryText`} numberOfLines={1}>
             {title}
           </Text>
@@ -52,5 +57,16 @@ const styles = StyleSheet.create({
   cardName: {
     marginLeft: 10,
     fontSize: 14,
+  },
+  dot: {
+    position: 'absolute',
+    top: -2,
+    right: -2,
+    width: 8,
+    height: 8,
+    borderRadius: 4,
+    backgroundColor: Colors.CrimsonRed,
+    borderWidth: 1,
+    borderColor: 'white',
   },
 });


### PR DESCRIPTION
This pull request enhances the Dust Analysis Report feature with improved UX, clearer labeling, and more comprehensive user education about dust and privacy. The changes include updates to UI components, translations, and logic for displaying dust-related information, as well as new explanations and visual cues to help users better understand and manage dust in their wallets.

**User education & modal improvements:**
- Added an "About Dust Report" info modal to the Dust Report screen, providing detailed explanations of dust, linked coins, and past dust spends, with localized content and a new info icon in the header. (`src/screens/DustReport/DustReportScreen.tsx`, `en.json`, `es.json`) 

**UI/UX improvements for dust labeling and clarity:**
- Changed summary card and spec labels from "Amount marked Do Not Spend" to simply "Amount" for clarity, and updated test assertions and specs accordingly. (`dustAnalysisReport.yaml`, `spec.md`, `DustReportScreen.tsx`) 
- Improved labeling for linked coins: "Linked to potential dust payment" is now shown for adjacent coins, and "Linked to potential dust spend" for descendant coins, with corresponding translation updates and test/spec changes. (`spec.md`, `en.json`, `es.json`, `DustReportScreen.tsx`, `UTXOLabeling.tsx`)

**Visual and information enhancements:**
- Added transaction and UTXO IDs to rows in the Dust Report for easier identification, and improved date formatting for transaction rows using `moment`. (`DustReportScreen.tsx`) 
- Updated the warning message in transaction details to clarify that dust UTXOs were spent, and adjusted spacing for improved readability. (`TransactionDetails.tsx`)

**Wallet UI indicators:**
- Added a visual dot indicator to the wallet "More" card when Do Not Spend UTXOs are present, propagating this state through wallet details and card components for better user awareness. (`VaultDetails.tsx`, `DetailCards.tsx`, `MoreCard.tsx`) 