### PR TITLE
Enhance active dust report with clarity & fix dust report mismatch(due to manual override)

### DIFF
--- a/src/context/Localization/language/en.json
+++ b/src/context/Localization/language/en.json
@@ -581,11 +581,11 @@
     "runReport": "Run Report",
     "tryAgain": "Try Again",
     "tooSmallToDonate": "Dust amount is too small to donate after fees",
-    "dustReportLearnMoreTitle": "About Dust Report",
-    "dustInfoWhatIs": "Dust is a very small amount of bitcoin (under 5,000 sats) sent to a wallet address to trace its activity. Spending it alongside other coins can link them on the blockchain and reduce your privacy.",
-    "dustInfoInitial": "Active Dust: A coin under 5,000 sats received on an address that has already been used before (a reused address). Spending it can reveal connections between your past and future transactions.",
-    "dustInfoAdjacent": "Linked Coins: Coins connected to dust in two ways. First, coins at the same address where dust was received (a poisoned address). Second, coins received in a transaction that spent a dust coin (a descendant coin).",
-    "dustInfoDescendant": "Past Dust Spends: Transactions in your history where a Do Not Spend coin was already used. These transactions have confirmed a link between your addresses and dust activity."
+    "dustReportLearnMoreTitle": "About Your Dust Report",
+    "dustInfoWhatIs": "The Dust Report scans your wallet for small coins that could be used to trace your transactions. Any suspicious coins are automatically marked as Do Not Spend to protect your privacy.",
+    "dustInfoInitial": "Coins marked Do Not Spend, and any related coins in your wallet, are isolated. Avoid spending them alongside your other funds, as this can link your addresses and reduce your privacy.",
+    "dustInfoAdjacent": "If you believe the flagged coins are dust, you can donate them. This removes them from your wallet entirely and also supports the app's development.",
+    "dustInfoDescendant": "If you think a coin was flagged by mistake, open UTXO Management, select the coin, and mark it as Spendable to use it normally again."
   },
   "vault": {
     "Addsigner": "Add a Signer",

--- a/src/context/Localization/language/es.json
+++ b/src/context/Localization/language/es.json
@@ -571,11 +571,11 @@
     "runReport": "Run Report",
     "tryAgain": "Try Again",
     "tooSmallToDonate": "Dust amount is too small to donate after fees",
-    "dustReportLearnMoreTitle": "About Dust Report",
-    "dustInfoWhatIs": "Dust is a very small amount of bitcoin (under 5,000 sats) sent to a wallet address to trace its activity. Spending it alongside other coins can link them on the blockchain and reduce your privacy.",
-    "dustInfoInitial": "Active Dust: A coin under 5,000 sats received on an address that has already been used before (a reused address). Spending it can reveal connections between your past and future transactions.",
-    "dustInfoAdjacent": "Linked Coins: Coins connected to dust in two ways. First, coins at the same address where dust was received (a poisoned address). Second, coins received in a transaction that spent a dust coin (a descendant coin).",
-    "dustInfoDescendant": "Past Dust Spends: Transactions in your history where a Do Not Spend coin was already used. These transactions have confirmed a link between your addresses and dust activity."
+    "dustReportLearnMoreTitle": "About Your Dust Report",
+    "dustInfoWhatIs": "The Dust Report scans your wallet for small coins that could be used to trace your transactions. Any suspicious coins are automatically marked as Do Not Spend to protect your privacy.",
+    "dustInfoInitial": "Coins marked Do Not Spend, and any related coins in your wallet, are isolated. Avoid spending them alongside your other funds, as this can link your addresses and reduce your privacy.",
+    "dustInfoAdjacent": "If you believe the flagged coins are dust, you can donate them. This removes them from your wallet entirely and also supports the app's development.",
+    "dustInfoDescendant": "If you think a coin was flagged by mistake, open UTXO Management, select the coin, and mark it as Spendable to use it normally again."
   },
   "vault": {
     "Addsigner": "Add a Signer",

--- a/src/hooks/useDustReport.ts
+++ b/src/hooks/useDustReport.ts
@@ -72,7 +72,7 @@ function deriveReportData(wallet: any): DustReportData {
   ];
 
   const activeDust = allUTXOs.filter(
-    (u) => u.spendability === 'doNotSpend' && u.dustReason === 'initial'
+    (u) => u.spendability === 'doNotSpend' && (u.dustReason === 'initial' || !u.dustReason) // for manually marked Do Not Spend coins without a dustReason, treat them as active dust for report purposes
   );
 
   const linkedCoins = allUTXOs.filter(


### PR DESCRIPTION
This pull request updates the dust report feature to improve clarity for users and to make the reporting logic more robust. The most important changes include more user-friendly and actionable dust report descriptions, and an update to the logic that determines which coins are considered "active dust" in the report.

**Localization and User Guidance Improvements:**

* Updated dust report explanatory text in both `en.json` and `es.json` to be clearer, more actionable, and less technical. The new descriptions focus on user privacy, what actions to take, and how to manage flagged coins.

**Dust Report Logic:**

* Modified the logic in `useDustReport.ts` so that coins manually marked as "Do Not Spend" (without a `dustReason`) are now included as "active dust" in the report. This ensures all relevant coins are surfaced to the user for review.